### PR TITLE
Implement option to only follow redirects on the same Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This will display help for the tool. Here are all the switches it supports.
 |------------------- |-------------------------------------------------------|----------------------------------------------------|
 | -H                 | Custom Header input                                   | httpx -H 'x-bug-bounty: hacker'                    |
 | -follow-redirects  | Follow URL redirects (default false)                  | httpx -follow-redirects                            |
+| -follow-host-redirects  | Follow URL redirects only when staying on the same host (default false)  | httpx -follow-host-redirects                                                                                                                         |
 | -http-proxy        | URL of the proxy server                               | httpx -http-proxy hxxp://proxy-host:80             |
 | -l                 | File containing host/urls to process                   | httpx -l hosts.txt                                |
 | -no-color          | Disable colors in the output.                         | httpx -no-color                                    |

--- a/cmd/httpx/httpx.go
+++ b/cmd/httpx/httpx.go
@@ -26,6 +26,7 @@ func main() {
 	httpxOptions.Timeout = time.Duration(options.Timeout) * time.Second
 	httpxOptions.RetryMax = options.Retries
 	httpxOptions.FollowRedirects = options.FollowRedirects
+	httpxOptions.FollowHostRedirects = options.FollowHostRedirects
 
 	httpxOptions.CustomHeaders = make(map[string]string)
 	for _, customHeader := range options.CustomHeaders {

--- a/cmd/httpx/options.go
+++ b/cmd/httpx/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	Version          bool
 	Verbose          bool
 	NoColor          bool
+	FollowHostRedirects	 bool
 }
 
 // ParseOptions parses the command line options for application
@@ -55,6 +56,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.StoreResponse, "store-response", false, "Store Response as domain.txt")
 	flag.StringVar(&options.StoreResponseDir, "store-response-dir", ".", "Store Response Directory (default current directory)")
 	flag.BoolVar(&options.FollowRedirects, "follow-redirects", false, "Follow Redirects")
+	flag.BoolVar(&options.FollowHostRedirects, "follow-host-redirects", false, "Only follow redirects on the same host")
 	flag.StringVar(&options.HttpProxy, "http-proxy", "", "Http Proxy")
 	flag.BoolVar(&options.JSONOutput, "json", false, "JSON Output")
 	flag.StringVar(&options.InputFile, "l", "", "File containing domains")

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -24,6 +24,7 @@ type HTTPX struct {
 	CustomHeaders map[string]string
 }
 
+
 // New httpx instance
 func New(options *Options) (*HTTPX, error) {
 	httpx := &HTTPX{}
@@ -39,11 +40,27 @@ func New(options *Options) (*HTTPX, error) {
 	retryablehttpOptions.RetryMax = httpx.Options.RetryMax
 
 	var redirectFunc = func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
+		return http.ErrUseLastResponse // Tell the http client to not follow redirect
 	}
 
-	if httpx.Options.FollowRedirects {
+	if httpx.Options.FollowRedirects{
+		// Follow redirects
 		redirectFunc = nil
+	}
+
+	if httpx.Options.FollowHostRedirects{
+		// Only follow redirects on the same host
+		redirectFunc = func(redirectedRequest *http.Request, previousRequest []*http.Request) error { // timo
+			// Check if we get a redirect to a differen host
+			var newHost = redirectedRequest.URL.Host
+			var oldHost = previousRequest[0].URL.Host
+			if newHost != oldHost{
+				return http.ErrUseLastResponse // Tell the http client to not follow redirect
+			} else {
+				// Go through with the redirect
+				return nil
+			}
+		}
 	}
 
 	transport := &http.Transport{

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -56,10 +56,9 @@ func New(options *Options) (*HTTPX, error) {
 			var oldHost = previousRequest[0].URL.Host
 			if newHost != oldHost{
 				return http.ErrUseLastResponse // Tell the http client to not follow redirect
-			} else {
-				// Go through with the redirect
-				return nil
-			}
+			} 
+			return nil
+			
 		}
 	}
 

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -14,6 +14,7 @@ type Options struct {
 
 	CustomHeaders    map[string]string
 	FollowRedirects  bool
+	FollowHostRedirects bool
 	DefaultUserAgent string
 
 	HttpProxy  string


### PR DESCRIPTION
This pull request implements and additional flag `-follow-host-redirects` \
With this flag the tool only follows redirects as long as they're on the same host. 

---

Lets say we request "https://example.com". 
We get a redirect response to "https://example.com/test". 
The tool makes the request and we get a response with a redirect to "https://authenticate.example.com". 
Because the redirect tries to change the "Host" the tool does no longer follow the redirect.

---

This feature can, for example, be useful when scanning a range of websites which like to (eventually) redirect to an authentication portal. \
Instead of getting either (1) no redirects or (2) only redirects which point to the authentication portal we get the resources which invoke the authentication redirect. 

Implemented was the change by implementing a more complex `redirectFunc` function which compares the original host with the next to-be requested host. \
If both redirect flags are set the "follow-host-redirects" flag takes priority.

I'm happy about any feedback about the feature/implementation.