### PR TITLE
Added option to include the raw response within the json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This will display help for the tool. Here are all the switches it supports.
 | -verbose           | Verbose Mode                                          | httpx -verbose                                     |
 | -version           | Prints current version of the httpx                   | httpx -version                                     |
 | -x                 | Request Method (default 'GET')                        | httpx -x HEAD                                      |
+| -response-in-stdout  | Include response in stdout (only works with -json)   | httpx -response-in-stdout                         |
 
 
 # Installation Instructions

--- a/cmd/httpx/httpx.go
+++ b/cmd/httpx/httpx.go
@@ -55,6 +55,7 @@ func main() {
 	scanopts.StoreResponseDirectory = options.StoreResponseDir
 	scanopts.Method = options.Method
 	scanopts.OutputServerHeader = options.OutputServerHeader
+	scanopts.ResponseInStdout = options.responseInStdout
 
 	// Try to create output folder if it doesnt exist
 	if options.StoreResponse && options.StoreResponseDir != "" && options.StoreResponseDir != "." {
@@ -178,6 +179,7 @@ type scanOptions struct {
 	StoreResponse          bool
 	StoreResponseDirectory string
 	OutputServerHeader     bool
+	ResponseInStdout	   bool
 }
 
 func analyze(hp *httpx.HTTPX, protocol string, domain string, port int, scanopts *scanOptions, output chan Result) {
@@ -243,6 +245,11 @@ retry:
 		builder.WriteString(fmt.Sprintf(" [%s]", serverHeader))
 	}
 
+	var serverResponseRaw = ""
+	if scanopts.ResponseInStdout {
+		serverResponseRaw = resp.Raw
+	}
+
 	// check for virtual host
 	isvhost := false
 	if scanopts.VHost {
@@ -262,7 +269,7 @@ retry:
 		}
 	}
 
-	output <- Result{URL: fullURL, ContentLength: resp.ContentLength, StatusCode: resp.StatusCode, Title: title, str: builder.String(), VHost: isvhost, WebServer: serverHeader}
+	output <- Result{URL: fullURL, ContentLength: resp.ContentLength, StatusCode: resp.StatusCode, Title: title, str: builder.String(), VHost: isvhost, WebServer: serverHeader, Response: serverResponseRaw}
 }
 
 // Result of a scan
@@ -275,6 +282,7 @@ type Result struct {
 	err           error
 	VHost         bool   `json:"vhost"`
 	WebServer     string `json:"webserver"`
+	Response      string `json:"serverResponse,omitempty"`
 }
 
 // JSON the result

--- a/cmd/httpx/options.go
+++ b/cmd/httpx/options.go
@@ -66,7 +66,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.Verbose, "verbose", false, "Verbose Mode")
 	flag.BoolVar(&options.NoColor, "no-color", false, "No Color")
 	flag.BoolVar(&options.OutputServerHeader, "web-server", false, "Prints out the Server header content")
-	flag.BoolVar(&options.responseInStdout, "response-in-stdout", false, "Server response directly in the tool output (-json only)")
+	flag.BoolVar(&options.responseInStdout, "response-in-json", false, "Server response directly in the tool output (-json only)")
 	flag.Parse()
 
 	// Read the inputs and configure the logging

--- a/cmd/httpx/options.go
+++ b/cmd/httpx/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	Verbose            bool
 	NoColor            bool
 	OutputServerHeader bool
+	responseInStdout bool
 }
 
 // ParseOptions parses the command line options for application
@@ -65,6 +66,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.Verbose, "verbose", false, "Verbose Mode")
 	flag.BoolVar(&options.NoColor, "no-color", false, "No Color")
 	flag.BoolVar(&options.OutputServerHeader, "web-server", false, "Prints out the Server header content")
+	flag.BoolVar(&options.responseInStdout, "response-in-stdout", false, "Server response directly in the tool output (-json only)")
 	flag.Parse()
 
 	// Read the inputs and configure the logging


### PR DESCRIPTION
When the `-response-in-json` and `-json` flag are set it includes the server response within the json "serverResponse" element. 

Is the `-response-in-json` flag not set, then the "serverResponse" element is omitted and tool output is the same as before.

![server_response](https://user-images.githubusercontent.com/18122064/84037314-ee32a200-a98d-11ea-8bbc-f1490404e229.png)

