### PR TITLE
Improve JSON output format

### DIFF
--- a/cmd/httpx/httpx.go
+++ b/cmd/httpx/httpx.go
@@ -88,6 +88,13 @@ func main() {
 			}
 			defer f.Close()
 		}
+		
+		f.WriteString("[\n")
+		defer func() {
+			f.Seek(-2, io.SeekEnd)
+			f.WriteString("\n]")
+		}()
+		
 		for r := range output {
 			if r.err != nil {
 				continue
@@ -97,10 +104,8 @@ func main() {
 				row = r.JSON()
 			}
 
-			fmt.Println(row)
-			if f != nil {
-				f.WriteString(row + "\n")
-			}
+			gologger.Printf(row + "\n")
+			f.WriteString(row + ",\n")
 		}
 	}(output)
 


### PR DESCRIPTION
* Now JSON output file will be valid JSON, as an array.
* Use `gologger` instead of `fmt` for printing output. We respect user `-silent`.
I think we don't need to check valid `f` here because if it is, `Fatalf` would terminated application.