### PR TITLE
Update title.go

### DIFF
--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -9,7 +9,7 @@ import (
 
 // ExtractTitle from a response
 func ExtractTitle(r *Response) string {
-	var re = regexp.MustCompile(`(?m)<\s*title *>(.*?)<\s*/\s*title>`)
+	var re = regexp.MustCompile(`(?im)<\s*title *>(.*?)<\s*/\s*title>`)
 	for _, match := range re.FindAllString(r.Raw, -1) {
 		return html.UnescapeString(trimTitleTags(match))
 	}


### PR DESCRIPTION
Make regexp for the title tag case-insensitive by adding the `i`, sometimes applications have `<TITLE>` rather than `<title>`