### PR TITLE
fixed setting custom headers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN go get -u github.com/golang/dep/cmd/dep
 WORKDIR /go/src/app
 
 # Install
-RUN go get -u github.com/projectdiscovery/httpx/cmd/httpx
+RUN go get -u github.com/n3k/httpx/cmd/httpx
 
 ENTRYPOINT ["httpx"]

--- a/cmd/httpx/httpx.go
+++ b/cmd/httpx/httpx.go
@@ -44,7 +44,7 @@ func main() {
 			continue
 		}
 		key = strings.TrimSpace(tokens[0])
-		value = strings.TrimSpace(tokens[1])
+		value = strings.TrimSpace(strings.Join(tokens[1:],""))
 
 		httpxOptions.CustomHeaders[key] = value
 	}


### PR DESCRIPTION
Previous to this, passing a header like User-Agent as the following: "User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0", trimed the value to "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv"