### PR TITLE
all: simplify logic statements and remove unneeded conversions

### DIFF
--- a/common/cache/dialer.go
+++ b/common/cache/dialer.go
@@ -39,7 +39,7 @@ func NewDialer(options Options) (DialerFunc, error) {
 				finalIps = append(finalIps, ip)
 			}
 		}
-		if err != nil || len(finalIps) <= 0 {
+		if err != nil || len(finalIps) < 0 {
 			return nil, &NoAddressFoundError{}
 		} // Dial to the IPs finally.
 		for _, ip := range ips {

--- a/common/cache/dialer.go
+++ b/common/cache/dialer.go
@@ -39,7 +39,7 @@ func NewDialer(options Options) (DialerFunc, error) {
 				finalIps = append(finalIps, ip)
 			}
 		}
-		if err != nil || len(finalIps) < 0 {
+		if err != nil || len(finalIps) == 0 {
 			return nil, &NoAddressFoundError{}
 		} // Dial to the IPs finally.
 		for _, ip := range ips {

--- a/common/customports/customport.go
+++ b/common/customports/customport.go
@@ -26,7 +26,7 @@ func (c *CustomPorts) Set(value string) error {
 	// splits on comma
 	potentialPorts := strings.Split(value, ",")
 
-	// check if port is a single integer value or needs to be expanded futher
+	// check if port is a single integer value or needs to be expanded further
 	for _, potentialPort := range potentialPorts {
 		potentialRange := strings.Split(strings.TrimSpace(potentialPort), "-")
 		// it's a single port?

--- a/common/fileutil/fileutil.go
+++ b/common/fileutil/fileutil.go
@@ -14,10 +14,7 @@ func FileExists(filename string) bool {
 // FolderExists checks if a folder exists
 func FolderExists(folderpath string) bool {
 	_, err := os.Stat(folderpath)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 // HasStdin determines if the user has piped input

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -117,7 +117,7 @@ func (h *HTTPX) Do(req *retryablehttp.Request) (*Response, error) {
 		return nil, err
 	}
 
-	resp.Raw = string(rawresp)
+	resp.Raw = rawresp
 
 	var respbody []byte
 	// websockets don't have a readable body

--- a/common/iputil/iputil.go
+++ b/common/iputil/iputil.go
@@ -5,11 +5,7 @@ import "net"
 // IsCidr determines if the given ip is a cidr range
 func IsCidr(ip string) bool {
 	_, _, err := net.ParseCIDR(ip)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // IsIP determines if the given string is a valid ip


### PR DESCRIPTION
Hi Project Discovery team,

This PR does the following:

- Removes unneeded negative length checks for slices
- Removes unneeded string to string conversions
- Fixes a typo 🤷 
- Simplifies if/else statements in methods that return a bool

All commits are signed and I tested my changes using both Go 1.15 and `tip` branch. Please, let me know if any change is needed from my side.

Best,
Miguel