### PR TITLE
Fixed reading input file with -l

### DIFF
--- a/common/fileutil/fileutil.go
+++ b/common/fileutil/fileutil.go
@@ -24,8 +24,10 @@ func HasStdin() bool {
 		return false
 	}
 
-	isPipedFromChrDev := (stat.Mode() & os.ModeCharDevice) == 0
-	isPipedFromFIFO := (stat.Mode() & os.ModeNamedPipe) != 0
+	mode := stat.Mode()
+
+	isPipedFromChrDev := (mode & os.ModeCharDevice) == 0
+	isPipedFromFIFO := (mode & os.ModeNamedPipe) != 0
 
 	return isPipedFromChrDev || isPipedFromFIFO
 }


### PR DESCRIPTION
Fixes #123 but is not related to #122.

This bug was introduced on #117, closing the input file has to be deferred or we will try to read from a closed stream.