### PR TITLE
Fix ci path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.31
           args: --timeout 5m
 
           # Optional: working directory, useful for monorepos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,6 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
           args: --timeout 5m
-          working-directory: cmd/httpx/
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.29.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.31.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/cmd/httpx/httpx.go
+++ b/cmd/httpx/httpx.go
@@ -554,7 +554,8 @@ retry:
 	)
 	dnsData, err := cache.GetDNSData(domain)
 	if dnsData != nil && err == nil {
-		ips = append(dnsData.IP4s, dnsData.IP6s...)
+		ips = append(ips, dnsData.IP4s...)
+		ips = append(ips, dnsData.IP6s...)
 		cnames = dnsData.CNAMEs
 	} else {
 		ips = append(ips, ip)


### PR DESCRIPTION
We don not need to set the `working-directory` because the `go.mod `is on the root path.