### PR TITLE
resolves teichopsia/httpx#1 - enhanced tls tracking

### DIFF
--- a/common/httpx/tls.go
+++ b/common/httpx/tls.go
@@ -1,17 +1,59 @@
 package httpx
 
 import (
+	"crypto/tls"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"github.com/projectdiscovery/httpx/common/cache"
 	"net/http"
 )
 
+type CertificateBlock struct {
+	Envelope map[string]string `json:"env,omitempty"`
+	Payload  []byte            `json:"payload,omitempty"`
+}
+
+type CertificateFold struct {
+	Certificate []CertificateBlock `json:"cert,omitempty"`
+	CertFold    bool               `json:"-"`
+}
+
 // TLSData contains the relevant Transport Layer Security information
-type TLSData struct {
+type TLSDataCore struct {
 	DNSNames         []string `json:"dns_names,omitempty"`
 	Emails           []string `json:"emails,omitempty"`
 	CommonName       []string `json:"common_name,omitempty"`
 	Organization     []string `json:"organization,omitempty"`
 	IssuerCommonName []string `json:"issuer_common_name,omitempty"`
 	IssuerOrg        []string `json:"issuer_organization,omitempty"`
+}
+
+type TLSData struct {
+	TLSDataCore
+	CertificateFold
+}
+
+// marshal TLSData using CertFold to determine if the subtree should be filtered
+func (t TLSData) MarshalJSON() ([]byte, error) {
+	tx := TLSDataCore{
+		t.DNSNames,
+		t.Emails,
+		t.CommonName,
+		t.Organization,
+		t.IssuerCommonName,
+		t.IssuerOrg,
+	}
+	if t.CertFold {
+		return json.Marshal(tx)
+	}
+	return json.Marshal(struct {
+		TLSDataCore
+		CertificateFold
+	}{
+		tx,
+		CertificateFold{t.Certificate, false},
+	})
 }
 
 // TLSGrab fills the TLSData
@@ -25,6 +67,16 @@ func (h *HTTPX) TLSGrab(r *http.Response) *TLSData {
 			tlsdata.Organization = append(tlsdata.Organization, certificate.Subject.Organization...)
 			tlsdata.IssuerOrg = append(tlsdata.IssuerOrg, certificate.Issuer.Organization...)
 			tlsdata.IssuerCommonName = append(tlsdata.IssuerCommonName, certificate.Issuer.CommonName)
+			tlsdata.CertFold = true
+			block := &pem.Block{Type: "CERTIFICATE", Bytes: []byte(certificate.Raw)}
+			tlsdata.Certificate = append(tlsdata.Certificate, CertificateBlock{map[string]string{
+				"version":    fmt.Sprintf("%d", r.TLS.Version),
+				"host":       r.Request.Host,
+				"sni":        r.TLS.ServerName,
+				"ip":         cache.GetDialedIP(r.Request.Host),
+				"cipher":     fmt.Sprintf("%d", r.TLS.CipherSuite),
+				"ciphername": fmt.Sprintf("%s", tls.CipherSuiteName(r.TLS.CipherSuite)),
+			}, pem.EncodeToMemory(block)})
 		}
 		return &tlsdata
 	}

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	maxFileNameLenght = 255
+	maxFileNameLength = 255 - 4 // leave room for extension
 	two               = 2
 )
 
@@ -28,6 +28,8 @@ type scanOptions struct {
 	OutputLocation         bool
 	OutputContentLength    bool
 	StoreResponse          bool
+	StoreTLS               bool
+	FullJSON               bool
 	OutputServerHeader     bool
 	OutputWebSocket        bool
 	OutputWithNoColor      bool
@@ -86,6 +88,8 @@ type Options struct {
 	ContentLength             bool
 	FollowRedirects           bool
 	StoreResponse             bool
+	StoreTLS                  bool
+	FullJSON                  bool
 	JSONOutput                bool
 	Silent                    bool
 	Version                   bool
@@ -127,7 +131,10 @@ func ParseOptions() *Options {
 	flag.Var(&options.CustomPorts, "ports", "ports range (nmap syntax: eg 1,2-10,11)")
 	flag.BoolVar(&options.ContentLength, "content-length", false, "Extracts content length")
 	flag.BoolVar(&options.StoreResponse, "sr", false, "Save response to file (default 'output')")
+	flag.BoolVar(&options.StoreTLS, "srtls", false, "Save response tls exchange to file (default 'output')")
+	flag.BoolVar(&options.FullJSON, "fulljson", false, "include entire tls exchange in json (enables -json)")
 	flag.StringVar(&options.StoreResponseDir, "srd", "output", "Save response directory")
+
 	flag.BoolVar(&options.FollowRedirects, "follow-redirects", false, "Follow Redirects")
 	flag.BoolVar(&options.FollowHostRedirects, "follow-host-redirects", false, "Only follow redirects on the same host")
 	flag.StringVar(&options.HTTPProxy, "http-proxy", "", "HTTP Proxy, eg http://127.0.0.1:8080")


### PR DESCRIPTION
no idea if this is of any value to the mainline. added it to solve specific use cases I had and it served as a forced crash course in golang. flames welcome. love the toolchain otherwise.

the problem I was trying to solve was basically:

```
cat inventory-cert-list | httpx -srtls -srd snuffy -sr -tls-probe -fulljson | jq ....
```

and end up with targetN.txt and targetN.tls where targetN.tls contained the tls parameters encountered and the PEM chain involved. -srtls solves that part.

the other issue is how to deal with the -json equivalent output. because adding the cert subtree is 'verbose' and there were use cases that wanted it present/omitted alike i added '-fulljson' to invoke -json behavior yet allow folding the cert subtree. yes you could filter this with a convoluted jq remap but due to the depth it was easier to handle in httpx before jq.

I probably chose an incomplete/poor solution by patching json marshalling but like I said, first stab at golang. the initial documentation for json tagging fields only omits if the RHS is not present. if your LHS is an array/slice it can't undo the key added so you have to filter before encountering it hence juggling TLSData around so much.

the entire use case for this is chasing down stray vips with stale/mismatched certificates. when I capture the host, sni, ip I can cross-reference against dns lints to fully enumerate pachinko mismatches in an environment. nothing worse than getting a weird response and wishing you had the tls environment for that request when it happened instead of chasing it down manually later