### PR TITLE
Improve GBK encode

### DIFF
--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -28,6 +28,27 @@ func ExtractTitle(r *Response) (title string) {
 
 			return string(titleUtf8)
 		}
+
+		// Content-Type from head tag
+		re = regexp.MustCompile(`(?im)\s*charset="(.*?)"|charset=(.*?)"\s*`)
+		var match = re.FindSubmatch(r.Data)
+		var mcontentType = ""
+		if len(match) != 0 {
+			for i, v := range match {
+				if string(v) != "" && i != 0 {
+					mcontentType = string(v)
+				}
+			}
+			mcontentType = strings.ToLower(mcontentType)
+		}
+		if strings.Contains(mcontentType, "gb2312") || strings.Contains(mcontentType, "gbk") {
+			titleUtf8, err := Decodegbk([]byte(title))
+			if err != nil {
+				return
+			}
+
+			return string(titleUtf8)
+		}
 	}
 
 	return


### PR DESCRIPTION
There are differences between the content-type in the header of some websites and the meta of HTML tags.

This will cause garbled characters when getting the title.

![微信截图_20201129141215](https://user-images.githubusercontent.com/18412368/100534718-e5d86700-324c-11eb-854f-087cb92b27d8.png)

I try to extract the content-type from the HTML tags and perform GBK encoding again after matching.