### PR TITLE
fix charset gbk and gb2312

### DIFF
--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -52,7 +52,7 @@ func ExtractTitle(r *Response) (title string) {
 		}
 	}
 
-	return
+	return //nolint
 }
 
 func trimTitleTags(title string) string {

--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -20,7 +20,8 @@ func ExtractTitle(r *Response) (title string) {
 		contentType := strings.Join(contentTypes, ";")
 
 		// special cases
-		if strings.Contains(contentType, "charset=GB2312") {
+		if strings.Contains(strings.ToLower(contentType), "charset=gb2312") ||
+			strings.Contains(strings.ToLower(contentType), "charset=gbk") {
 			titleUtf8, err := Decodegbk([]byte(title))
 			if err != nil {
 				return


### PR DESCRIPTION
Before:
echo 5s.alipay.com|./httpx -title -content-length -status-code -silent -follow-redirects
https://5s.alipay.com [404] [846] [??????-404]

After repair:
echo 5s.alipay.com|./httpx -title -content-length -status-code -silent -follow-redirects
https://5s.alipay.com [404] [846] [出错了-404]