### PR TITLE
fixed build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14-alpine AS builder
 RUN apk add --no-cache git
-RUN GO111MODULE=auto go get -u -v github.com/projectdiscovery/httpx/cmd/httpx
+RUN GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx
 
 FROM alpine:latest
 COPY --from=builder /go/bin/httpx /usr/local/bin/


### PR DESCRIPTION
`go get -u` was causing the module dependencies to be updated (`-u`) ignoring the version declarations in your project's `go.mod` file thus causing a build error. 