### PR TITLE
fix duplicated result when use CIDR targets and -ports

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Exposed Atoms Pvt Ltd
+Copyright (c) 2021 ProjectDiscovery, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Download latest binary from https://github.com/projectdiscovery/httpx/releases
 httpx requires **go1.14+** to install successfully. Run the following command to get the repo - 
 
 ```sh
-▶ GO111MODULE=on go get -u -v github.com/projectdiscovery/httpx/cmd/httpx
+▶ GO111MODULE=on go get -v github.com/projectdiscovery/httpx/cmd/httpx
 ```
 
 ### From Github

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -410,9 +410,9 @@ func process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.HTTPX, proto
 		for port, wantedProtocol := range customport.Ports {
 			for _, method := range scanopts.Methods {
 				wg.Add()
-				go func(port int, method, protocol string) {
+				go func(port int, method, protocol string, tg string) {
 					defer wg.Done()
-					r := analyze(hp, protocol, target, port, method, scanopts)
+					r := analyze(hp, protocol, tg, port, method, scanopts)
 					output <- r
 					if scanopts.TLSProbe && r.TLSData != nil {
 						scanopts.TLSProbe = false
@@ -423,7 +423,7 @@ func process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.HTTPX, proto
 							process(tt, wg, hp, protocol, scanopts, output)
 						}
 					}
-				}(port, method, wantedProtocol)
+				}(port, method, wantedProtocol, target)
 			}
 		}
 	}


### PR DESCRIPTION
## Describe

When use CIDR targets and -ports, result maybe duplicated cause the parameter ```target``` pass to ```analyze()``` is duplicated.

## Replicate

Add ```fmt.Println(domain)``` in analyze function and execute ```echo CIDR | ./httpx  -status-code -threads 50 -title  -ports 80```, it's very clear and easy to replicate.

I think it's related to #63 .