### PR TITLE
Sort technologies before output to make diffing results easier

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -790,6 +791,7 @@ retry:
 		}
 
 		if len(technologies) > 0 {
+			sort.Strings(technologies)
 			technologies := strings.Join(technologies, ",")
 
 			builder.WriteString(" [")


### PR DESCRIPTION
Technologies presented in a predictable order makes diffing to previous scans easier. It can also be easier to spot outliers within a single list of results when the same tech stack is displayed consistently.