### PR TITLE
Fixing stream mode with path parameter

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -22,6 +22,7 @@ var httpTestcases = map[string]testutils.TestCase{
 	"Regression test for: https://github.com/projectdiscovery/httpx/issues/277": &issue277{}, // scheme://host:port via stdin
 	"Regression test for: https://github.com/projectdiscovery/httpx/issues/303": &issue303{}, // misconfigured gzip header with uncompressed body
 	"Regression test for: https://github.com/projectdiscovery/httpx/issues/400": &issue400{}, // post operation with body
+	"Regression test for: https://github.com/projectdiscovery/httpx/issues/414": &issue414{}, // stream mode with path
 }
 
 type standardHttpGet struct {
@@ -206,6 +207,34 @@ func (h *issue400) Execute() error {
 	}
 	if len(results) != 1 {
 		return errIncorrectResultsCount(results)
+	}
+	return nil
+}
+
+type issue414 struct{}
+
+func (h *issue414) Execute() error {
+	var ts *httptest.Server
+	uripath := "/path"
+	router := httprouter.New()
+	router.POST(uripath, httprouter.Handle(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		w.Header().Add("Content-Type", "application/json")
+		data, _ := ioutil.ReadAll(r.Body)
+		fmt.Fprintf(w, "data received %s", data)
+	}))
+	ts = httptest.NewServer(router)
+	defer ts.Close()
+
+	results, err := testutils.RunHttpxAndGetResults(ts.URL, debug, fmt.Sprintf("-path '%s'", uripath))
+	if err != nil {
+		return err
+	}
+	if len(results) != 1 {
+		return errIncorrectResultsCount(results)
+	}
+	expected := ts.URL + uripath
+	if !strings.EqualFold(results[0], expected) {
+		return errIncorrectResult(results[0], expected)
 	}
 	return nil
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -256,14 +256,16 @@ func New(options *Options) (*Runner, error) {
 	return runner, nil
 }
 
-func (r *Runner) prepareInput() {
+func (r *Runner) prepareInputPaths() {
 	// Check if the user requested multiple paths
 	if fileutil.FileExists(r.options.RequestURIs) {
 		r.options.requestURIs = fileutilz.LoadFile(r.options.RequestURIs)
 	} else if r.options.RequestURIs != "" {
 		r.options.requestURIs = strings.Split(r.options.RequestURIs, ",")
 	}
+}
 
+func (r *Runner) prepareInput() {
 	// check if file has been provided
 	var numHosts int
 	if fileutil.FileExists(r.options.InputFile) {
@@ -487,6 +489,8 @@ func (r *Runner) RunEnumeration() {
 			gologger.Fatal().Msgf("Could not create output directory '%s': %s\n", r.options.StoreResponseDir, err)
 		}
 	}
+
+	r.prepareInputPaths()
 
 	var streamChan chan string
 	if r.options.Stream {


### PR DESCRIPTION
Before:
```
$ echo www.example.com | go run . -t 1 -path /test -stream -silent
https://www.example.com
```
After:
```
$ echo www.example.com | go run . -t 1 -path /test -stream -silent
https://www.example.com/test
```