### PR TITLE
Make http request dump with debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,13 @@ CONFIGURATIONS:
    -sd, -skip-dedupe                  Disable dedupe input items (only used with stream mode)
 
 DEBUG:
-   -silent   Silent mode
-   -verbose  Verbose mode
-   -version  Display version
-   -debug    Debug mode
-   -stats    Display scan statistic
+   -silent      Silent mode
+   -verbose     Verbose mode
+   -version     Display version
+   -debug       Debug mode
+   -debug-req   Show all sent requests
+   -debug-resp  Show all received responses
+   -stats       Display scan statistic
 
 OPTIMIZATIONS:
    -retries int                 Number of retries

--- a/runner/options.go
+++ b/runner/options.go
@@ -167,6 +167,8 @@ type Options struct {
 	OutputCName               bool
 	Unsafe                    bool
 	Debug                     bool
+	DebugRequests             bool
+	DebugResponse             bool
 	Pipeline                  bool
 	HTTP2Probe                bool
 	OutputCDN                 bool
@@ -295,6 +297,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.Verbose, "verbose", false, "Verbose mode"),
 		flagSet.BoolVar(&options.Version, "version", false, "Display version"),
 		flagSet.BoolVar(&options.Debug, "debug", false, "Debug mode"),
+		flagSet.BoolVar(&options.DebugRequests, "debug-req", false, "Show all sent requests"),
+		flagSet.BoolVar(&options.DebugResponse, "debug-resp", false, "Show all received responses"),
 		flagSet.BoolVar(&options.ShowStatistics, "stats", false, "Display scan statistic"),
 	)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -846,6 +846,15 @@ retry:
 	}
 	fullURL = parsedURL.String()
 
+	if r.options.Debug || r.options.DebugRequests {
+		gologger.Info().Msgf("Dumped HTTP request for %s\n\n", fullURL)
+		gologger.Print().Msgf("%s", string(requestDump))
+	}
+	if r.options.Debug || r.options.DebugResponse {
+		gologger.Info().Msgf("Dumped HTTP response for %s\n\n", fullURL)
+		gologger.Print().Msgf("%s", string(resp.Raw))
+	}
+
 	builder := &strings.Builder{}
 	builder.WriteString(stringz.RemoveURLDefaultPort(fullURL))
 


### PR DESCRIPTION
Added http request and response dump for `debug` flag. Also added new flags `debug-req` and `debug-resp` to dump only requests or responses respectively.
This PR fixes #419.

Example output:
```
$ echo https://google.com | ./httpx --debug
    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/              v1.1.4-dev

                projectdiscovery.io

Use with caution. You are responsible for your actions.
Developers assume no liability and are not responsible for any misuse or damage.
[INF] Dumped HTTP request for https://google.com:443

GET / HTTP/1.1
Host: google.com
User-Agent: Mozilla/5.0 (Linux; Android 9; SM-G965F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
Accept-Charset: utf-8
Accept-Encoding: gzip

[INF] Dumped HTTP response for https://google.com:443

HTTP/1.1 301 Moved Permanently
Connection: close
Content-Length: 220
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000
Cache-Control: public, max-age=2592000
Content-Type: text/html; charset=UTF-8
Date: Sat, 23 Oct 2021 11:30:30 GMT
Expires: Mon, 22 Nov 2021 11:30:30 GMT
Location: https://www.google.com/
Server: gws
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0

<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="https://www.google.com/">here</A>.
</BODY></HTML>
https://google.com
```