### PR TITLE
Fix npe on debug output

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -850,7 +850,7 @@ retry:
 		gologger.Info().Msgf("Dumped HTTP request for %s\n\n", fullURL)
 		gologger.Print().Msgf("%s", string(requestDump))
 	}
-	if r.options.Debug || r.options.DebugResponse {
+	if (r.options.Debug || r.options.DebugResponse) && resp != nil {
 		gologger.Info().Msgf("Dumped HTTP response for %s\n\n", fullURL)
 		gologger.Print().Msgf("%s", string(resp.Raw))
 	}


### PR DESCRIPTION
Fix panic in debug output on unsuccessful request - https://github.com/projectdiscovery/httpx/pull/425#issuecomment-975030871.
```bash
$ echo abc | ./httpx -debug
...
panic: runtime error: invalid memory address or nil pointer dereference                                                                             
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xa54a09]

goroutine 27 [running]:
github.com/projectdiscovery/httpx/runner.(*Runner).analyze(_, _, {_, _}, {_, _}, {_, _}, {0xc00023e070, 0x3}, ...)
        /home/zerodivisi0n/go/src/github.com/projectdiscovery/httpx/runner/runner.go:855 +0x1089
github.com/projectdiscovery/httpx/runner.(*Runner).process.func1({0xc00023e070, 0x3}, {0xba3512, 0x3}, {0xba9fbb, 0xa})
        /home/zerodivisi0n/go/src/github.com/projectdiscovery/httpx/runner/runner.go:648 +0x125
created by github.com/projectdiscovery/httpx/runner.(*Runner).process
        /home/zerodivisi0n/go/src/github.com/projectdiscovery/httpx/runner/runner.go:646 +0x945
```

The panic occurs here: https://github.com/projectdiscovery/httpx/blob/f408ed6329f989c798a7a8f9375c14af210738fe/runner/runner.go#L855

I decided to add a check here, and not below (after handling the error) so that the request body is always displayed and the code with the debug output is in one place.