### PR TITLE
fix truncation of long response file names

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	maxFileNameLength = 255
+	// The maximum file length is 251 (255 - 4 bytes for ".ext" suffix)
+	maxFileNameLength = 251
 	two               = 2
 	DefaultResumeFile = "resume.cfg"
 )

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1173,9 +1173,9 @@ retry:
 
 		// On various OS the file max file name length is 255 - https://serverfault.com/questions/9546/filename-length-limits-on-linux
 		// Truncating length at 255
-		if len(domainFile) >= maxFileNameLength-4 {
+		if len(domainFile) >= maxFileNameLength {
 			// leaving last 4 bytes free to append ".txt"
-			domainFile = domainFile[:maxFileNameLength-4]
+			domainFile = domainFile[:maxFileNameLength]
 		}
 
 		domainFile = strings.ReplaceAll(domainFile, "/", "_") + ".txt"

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1173,9 +1173,9 @@ retry:
 
 		// On various OS the file max file name length is 255 - https://serverfault.com/questions/9546/filename-length-limits-on-linux
 		// Truncating length at 255
-		if len(domainFile) >= maxFileNameLength {
+		if len(domainFile) >= maxFileNameLength-4 {
 			// leaving last 4 bytes free to append ".txt"
-			domainFile = domainFile[:maxFileNameLength-1]
+			domainFile = domainFile[:maxFileNameLength-4]
 		}
 
 		domainFile = strings.ReplaceAll(domainFile, "/", "_") + ".txt"


### PR DESCRIPTION
Fix for a "file name too long" error that I got with "httpx -sr".

```
$ echo "https://example.com/8444441444444444444444444444444444444444444444444444444444444444444444444444455553333333333333333333333333333333333333333333333aaaaaaa2exasdasdasdasdasdasdadasdasdasdasd2221111111lllllllllllllllllllllllla111222222222mplabcdefghijkl123456789" | httpx -sr -srd test -debug
...
[WRN] Could not write response at path 'test/example.com_8444441444444444444444444444444444444444444444444444444444444444444444444444455553333333333333333333333333333333333333333333333aaaaaaa2exasdasdasdasdasdasdadasdasdasdasd2221111111lllllllllllllllllllllllla111222222222mplabcdefghijkl123456789.txt', to disk: open test/example.com_8444441444444444444444444444444444444444444444444444444444444444444444444444455553333333333333333333333333333333333333333333333aaaaaaa2exasdasdasdasdasdasdadasdasdasdasd2221111111lllllllllllllllllllllllla111222222222mplabcdefghijkl123456789.txt: file name too long
```