### PR TITLE
Adding support for custom resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ OUTPUT:
    -csv                              Output in CSV format
 
 CONFIGURATIONS:
+   -r, -resolvers string[]       List of custom resolvers (file or comma separated)
    -allow string[]               Allowed list of IP/CIDR's to process (file or comma separated)
    -deny string[]                Denied list of IP/CIDR's to process (file or comma separated)
    -random-agent                 Enable Random User-Agent to use (default true)
@@ -323,7 +324,8 @@ https://support.hackerone.com
 - `vhost`, `http2`, `pipeline`, `ports`, `csp-probe`, `tls-probe` and `path` are unique flag with different probes.
 - Unique flags should be used for specific use cases instead of running them as default with other flags.
 - When using `json` flag, all the information (default probes) included in the JSON output.
-
+- Custom resolver supports multiple protocol (**doh|tcp|udp**) in form of `protocol:resolver:port`  (eg **udp:127.0.0.1:53**)
+- Invalid custom resolvers/files are ignored.
 
 # Acknowledgement
 

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -44,6 +44,9 @@ func New(options *Options) (*HTTPX, error) {
 	fastdialerOpts.Deny = options.Deny
 	fastdialerOpts.Allow = options.Allow
 	fastdialerOpts.WithDialerHistory = true
+	if len(options.Resolvers) > 0 {
+		fastdialerOpts.BaseResolvers = options.Resolvers
+	}
 	dialer, err := fastdialer.NewDialer(fastdialerOpts)
 	if err != nil {
 		return nil, fmt.Errorf("could not create resolver cache: %s", err)

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -36,6 +36,7 @@ type Options struct {
 	MaxResponseBodySizeToSave int64
 	MaxResponseBodySizeToRead int64
 	UnsafeURI                 string
+	Resolvers                 []string
 }
 
 // DefaultOptions contains the default options

--- a/runner/options.go
+++ b/runner/options.go
@@ -274,6 +274,7 @@ func ParseOptions() *Options {
 	)
 
 	createGroup(flagSet, "configs", "Configurations",
+		flagSet.NormalizedStringSliceVarP(&options.Resolvers, "resolvers", "r", []string{}, "List of custom resolvers (file or comma separated)"),
 		flagSet.Var(&options.Allow, "allow", "Allowed list of IP/CIDR's to process (file or comma separated)"),
 		flagSet.Var(&options.Deny, "deny", "Denied list of IP/CIDR's to process (file or comma separated)"),
 		flagSet.BoolVar(&options.RandomAgent, "random-agent", true, "Enable Random User-Agent to use"),
@@ -290,7 +291,6 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.Stream, "stream", "s", false, "Stream mode - start elaborating input targets without sorting"),
 		flagSet.BoolVarP(&options.SkipDedupe, "skip-dedupe", "sd", false, "Disable dedupe input items (only used with stream mode)"),
 		flagSet.BoolVarP(&options.ProbeAllIPS, "probe-all-ips", "pa", false, "Probe all the ips associated with same host"),
-		flagSet.NormalizedStringSliceVarP(&options.Resolvers, "resolvers", "r", []string{}, "List of resolvers (file or comma separated) - each resolver can be in the form protocol:ip|hostname:port - invalid files/resolvers ignored"),
 	)
 
 	createGroup(flagSet, "debug", "Debug",

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -108,6 +108,7 @@ func New(options *Options) (*Runner, error) {
 	if httpxOptions.MaxResponseBodySizeToSave > httpxOptions.MaxResponseBodySizeToRead {
 		httpxOptions.MaxResponseBodySizeToSave = httpxOptions.MaxResponseBodySizeToRead
 	}
+	httpxOptions.Resolvers = options.Resolvers
 
 	var key, value string
 	httpxOptions.CustomHeaders = make(map[string]string)


### PR DESCRIPTION
This PR adds support for custom resolvers from CLI/File. Example:

```
$ cat resolvers.txt
1.1.1.1
$ echo aaaa | go run . -resolvers resolvers.txt,2.2.2.2
```