### PR TITLE
Adding support for lines/words matchers/filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,19 @@ httpx is a fast and multi-purpose HTTP toolkit allow to run multiple probers usi
 
 ### Supported probes:-
 
-| Probes             | Default check   | Probes             | Default check   |
-|--------------------|-----------------|--------------------|-----------------|
-| URL                | true            | IP                 | true            |
-| Title              | true            | CNAME              | true            |
-| Status Code        | true            | Raw HTTP           | false           |
-| Content Length     | true            | HTTP2              | false           |
-| TLS Certificate    | true            | HTTP 1.1 Pipeline  | false           |
-| CSP Header         | true            | Virtual host       | false           |
-| Location Header    | true            | CDN                | false           |
-| Web Server         | true            | Path               | false           |
-| Web Socket         | true            | Ports              | false           |
-| Response Time      | true            | Request method     | false           |
+| Probes          | Default check | Probes            | Default check |
+| --------------- | ------------- | ----------------- | ------------- |
+| URL             | true          | IP                | true          |
+| Title           | true          | CNAME             | true          |
+| Status Code     | true          | Raw HTTP          | false         |
+| Content Length  | true          | HTTP2             | false         |
+| Line Count      | true          | Word Count        | true          |
+| TLS Certificate | true          | HTTP 1.1 Pipeline | false         |
+| CSP Header      | true          | Virtual host      | false         |
+| Location Header | true          | CDN               | false         |
+| Web Server      | true          | Paths             | false         |
+| Web Socket      | true          | Ports             | false         |
+| Response Time   | true          | Request Method    | false         |
 
 
 # Installation Instructions
@@ -87,6 +88,8 @@ PROBES:
    -sc, -status-code     Display Status Code
    -td, -tech-detect     Display wappalyzer based technology detection
    -cl, -content-length  Display Content-Length
+   -lc, -line-count      Display Response body line count
+   -wc, -word-count      Display Response body word count
    -server, -web-server  Display Server header
    -ct, -content-type    Display Content-Type header
    -rt, -response-time   Display the response time
@@ -105,12 +108,16 @@ MATCHERS:
    -ms, -match-string string   Match response with given string
    -mr, -match-regex string    Match response with specific regex
    -er, -extract-regex string  Display response content with matched regex
+   -mlc, -match-line-count string  Match Response body line count
+   -mwc, -match-word-count string  Match Response body word count
 
 FILTERS:
    -fc, -filter-code string    Filter response with given status code (-fc 403,401)
    -fl, -filter-length string  Filter response with given content length (-fl 23,33)
    -fs, -filter-string string  Filter response with specific string
    -fe, -filter-regex string   Filter response with specific regex
+   -flc, -filter-line-count string  Filter Response body line count
+   -fwc, -filter-word-count string  Filter Response body word count
 
 RATE-LIMIT:
    -t, -threads int      Number of threads (default 50)

--- a/runner/options.go
+++ b/runner/options.go
@@ -233,6 +233,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ContentLength, "content-length", "cl", false, "Display Content-Length"),
 		flagSet.BoolVarP(&options.OutputServerHeader, "web-server", "server", false, "Display Server header"),
 		flagSet.BoolVarP(&options.OutputContentType, "content-type", "ct", false, "Display Content-Type header"),
+		flagSet.BoolVarP(&options.OutputLinesCount, "line-count", "lc", false, "Display Response body line count"),
+		flagSet.BoolVarP(&options.OutputWordsCount, "word-count", "wc", false, "Display Response body word count"),
 		flagSet.BoolVarP(&options.OutputResponseTime, "response-time", "rt", false, "Display the response time"),
 		flagSet.BoolVar(&options.ExtractTitle, "title", false, "Display page title"),
 		flagSet.BoolVar(&options.Location, "location", false, "Display Location header"),
@@ -243,8 +245,6 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.OutputCDN, "cdn", false, "Display if CDN in use"),
 		flagSet.BoolVar(&options.Probe, "probe", false, "Display probe status"),
 		flagSet.StringVarP(&options.OutputExtractRegex, "extract-regex", "er", "", "Display response content with matched regex"),
-		flagSet.BoolVarP(&options.OutputLinesCount, "line-count", "lc", false, " Display Response body line count"),
-		flagSet.BoolVarP(&options.OutputWordsCount, "words-count", "wc", false, " Display Response body words count"),
 	)
 
 	createGroup(flagSet, "matchers", "Matchers",
@@ -253,7 +253,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputMatchString, "match-string", "ms", "", "Match response with given string"),
 		flagSet.StringVarP(&options.OutputMatchRegex, "match-regex", "mr", "", "Match response with specific regex"),
 		flagSet.StringVarP(&options.OutputMatchLinesCount, "match-line-count", "mlc", "", "Match Response body line count"),
-		flagSet.StringVarP(&options.OutputMatchWordsCount, "match-words-count", "mwc", "", "Match Response body words count"),
+		flagSet.StringVarP(&options.OutputMatchWordsCount, "match-word-count", "mwc", "", "Match Response body word count"),
 	)
 
 	createGroup(flagSet, "filters", "Filters",
@@ -262,7 +262,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputFilterString, "filter-string", "fs", "", "Filter response with specific string"),
 		flagSet.StringVarP(&options.OutputFilterRegex, "filter-regex", "fe", "", "Filter response with specific regex"),
 		flagSet.StringVarP(&options.OutputFilterLinesCount, "filter-line-count", "flc", "", "Filter Response body line count"),
-		flagSet.StringVarP(&options.OutputFilterWordsCount, "filter-words-count", "fwc", "", "Filter Response body words count"),
+		flagSet.StringVarP(&options.OutputFilterWordsCount, "filter-word-count", "fwc", "", "Filter Response body word count"),
 	)
 
 	createGroup(flagSet, "rate-limit", "Rate-Limit",


### PR DESCRIPTION
## Description
This PR adds support for lines/words count matcher/filters. The new flags are the following ones:

```yaml
   -lc, -line-count      Display Response body line count
   -wc, -word-count      Display Response body word count
   
   -mlc, -match-line-count string  Match Response body line count
   -mwc, -match-word-count string  Match Response body word count
   
   -flc, -filter-line-count string  Filter Response body line count
   -fwc, -filter-word-count string  Filter Response body word count
```