### PR TITLE
Add support for favicon hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ MATCHERS:
    -er, -extract-regex string  Display response content with matched regex
    -mlc, -match-line-count string  Match Response body line count
    -mwc, -match-word-count string  Match Response body word count
+   -mfc, -match-favicon string[]   Match response with specific favicon
 
 FILTERS:
    -fc, -filter-code string    Filter response with given status code (-fc 403,401)
@@ -118,12 +119,14 @@ FILTERS:
    -fe, -filter-regex string   Filter response with specific regex
    -flc, -filter-line-count string  Filter Response body line count
    -fwc, -filter-word-count string  Filter Response body word count
+   -ffc, -filter-favicon string[]   Filter response with specific favicon
 
 RATE-LIMIT:
    -t, -threads int      Number of threads (default 50)
    -rl, -rate-limit int  Maximum requests to send per second (default 150)
 
 MISCELLANEOUS:
+   -favicon             Probes for favicon ("favicon.ico" as path) and display phythonic hash
    -tls-grab            Perform TLS(SSL) data grabbing
    -tls-probe           Send HTTP probes on the extracted TLS domains
    -csp-probe           Send HTTP probes on the extracted CSP domains
@@ -328,8 +331,8 @@ https://support.hackerone.com
 - As default, **httpx** checks for `HTTPS` probe and fall-back to `HTTP` only if `HTTPS` is not reachable.
 - For printing both HTTP/HTTPS results, `no-fallback` flag can be used.
 - Custom scheme for ports can be defined, for example `-ports http:443,http:80,https:8443`
-- `vhost`, `http2`, `pipeline`, `ports`, `csp-probe`, `tls-probe` and `path` are unique flag with different probes.
-- Unique flags should be used for specific use cases instead of running them as default with other flags.
+- `favicon`,`vhost`, `http2`, `pipeline`, `ports`, `csp-probe`, `tls-probe` and `path` are unique flag with different probes.
+- Unique flags should be used for specific use cases instead of running them as default with other probes.
 - When using `json` flag, all the information (default probes) included in the JSON output.
 - Custom resolver supports multiple protocol (**doh|tcp|udp**) in form of `protocol:resolver:port`  (eg **udp:127.0.0.1:53**)
 - Invalid custom resolvers/files are ignored.

--- a/common/slice/slice.go
+++ b/common/slice/slice.go
@@ -10,6 +10,16 @@ func IntSliceContains(sl []int, v int) bool {
 	return false
 }
 
+// UIntSliceContains check if a slice contains the specified uint value
+func UInt32SliceContains(sl []uint32, v uint32) bool {
+	for _, vv := range sl {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}
+
 // ToSlice creates a slice with all string keys from a map
 func ToSlice(m map[string]struct{}) (s []string) {
 	for k := range m {

--- a/common/stringz/stringz.go
+++ b/common/stringz/stringz.go
@@ -106,12 +106,12 @@ func GetInvalidURI(rawURL string) (bool, string) {
 	return false, ""
 }
 
-func FaviconHash(data []byte) uint32 {
+func FaviconHash(data []byte) int32 {
 	stdBase64 := base64.StdEncoding.EncodeToString(data)
 	stdBase64 = InsertInto(stdBase64, 76, '\n')
 	hasher := murmur3.New32WithSeed(0)
 	hasher.Write([]byte(stdBase64))
-	return hasher.Sum32()
+	return int32(hasher.Sum32())
 }
 
 func InsertInto(s string, interval int, sep rune) string {

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	golang.org/x/text v0.3.7
 )
 
+require github.com/spaolacci/murmur3 v1.1.0
+
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsR
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/runner/options.go
+++ b/runner/options.go
@@ -116,10 +116,8 @@ type Options struct {
 	CustomPorts               customport.CustomPorts
 	matchStatusCode           []int
 	matchContentLength        []int
-	matchFavicon              []uint32
 	filterStatusCode          []int
 	filterContentLength       []int
-	filterFavicon             []uint32
 	Output                    string
 	StoreResponseDir          string
 	HTTPProxy                 string
@@ -204,8 +202,8 @@ type Options struct {
 	ProbeAllIPS               bool
 	Resolvers                 goflags.NormalizedStringSlice
 	Favicon                   bool
-	OutputFilterFavicon       string
-	OutputMatchFavicon        string
+	OutputFilterFavicon       goflags.NormalizedStringSlice
+	OutputMatchFavicon        goflags.NormalizedStringSlice
 }
 
 // ParseOptions parses the command line options for application
@@ -244,7 +242,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputMatchString, "match-string", "ms", "", "Match response with given string"),
 		flagSet.StringVarP(&options.OutputMatchRegex, "match-regex", "mr", "", "Match response with specific regex"),
 		flagSet.StringVarP(&options.OutputExtractRegex, "extract-regex", "er", "", "Display response content with matched regex"),
-		flagSet.StringVarP(&options.OutputMatchFavicon, "match-favicon", "mfc", "", "Match response with specific favicon"),
+		flagSet.NormalizedStringSliceVarP(&options.OutputMatchFavicon, "match-favicon", "mfc", []string{}, "Match response with specific favicon"),
 	)
 
 	createGroup(flagSet, "filters", "Filters",
@@ -252,7 +250,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputFilterContentLength, "filter-length", "fl", "", "Filter response with given content length (-fl 23,33)"),
 		flagSet.StringVarP(&options.OutputFilterString, "filter-string", "fs", "", "Filter response with specific string"),
 		flagSet.StringVarP(&options.OutputFilterRegex, "filter-regex", "fe", "", "Filter response with specific regex"),
-		flagSet.StringVarP(&options.OutputFilterFavicon, "filter-favicon", "ffc", "", "Filter response with specific favicon"),
+		flagSet.NormalizedStringSliceVarP(&options.OutputFilterFavicon, "filter-favicon", "ffc", []string{}, "Filter response with specific favicon"),
 	)
 
 	createGroup(flagSet, "rate-limit", "Rate-Limit",
@@ -367,16 +365,10 @@ func (options *Options) validateOptions() {
 	if options.matchContentLength, err = stringz.StringToSliceInt(options.OutputMatchContentLength); err != nil {
 		gologger.Fatal().Msgf("Invalid value for match content length option: %s\n", err)
 	}
-	if options.matchFavicon, err = stringz.StringToSliceUInt32(options.OutputMatchFavicon); err != nil {
-		gologger.Fatal().Msgf("Invalid value for match favicon option: %s\n", err)
-	}
 	if options.filterStatusCode, err = stringz.StringToSliceInt(options.OutputFilterStatusCode); err != nil {
 		gologger.Fatal().Msgf("Invalid value for filter status code option: %s\n", err)
 	}
 	if options.filterContentLength, err = stringz.StringToSliceInt(options.OutputFilterContentLength); err != nil {
-		gologger.Fatal().Msgf("Invalid value for filter content length option: %s\n", err)
-	}
-	if options.filterFavicon, err = stringz.StringToSliceUInt32(options.OutputFilterFavicon); err != nil {
 		gologger.Fatal().Msgf("Invalid value for filter content length option: %s\n", err)
 	}
 	if options.OutputFilterRegex != "" {

--- a/runner/options.go
+++ b/runner/options.go
@@ -250,7 +250,6 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.OutputCDN, "cdn", false, "Display if CDN in use"),
 		flagSet.BoolVar(&options.Probe, "probe", false, "Display probe status"),
 		flagSet.BoolVar(&options.Favicon, "favicon", false, "Probes for favicon (\"favicon.ico\" as path) and display phythonic hash"),
-		flagSet.StringVarP(&options.OutputExtractRegex, "extract-regex", "er", "", "Display response content with matched regex"),
 	)
 
 	createGroup(flagSet, "matchers", "Matchers",

--- a/runner/options.go
+++ b/runner/options.go
@@ -249,7 +249,6 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.OutputCName, "cname", false, "Display Host cname"),
 		flagSet.BoolVar(&options.OutputCDN, "cdn", false, "Display if CDN in use"),
 		flagSet.BoolVar(&options.Probe, "probe", false, "Display probe status"),
-		flagSet.BoolVar(&options.Favicon, "favicon", false, "Probes for favicon (\"favicon.ico\" as path) and display phythonic hash"),
 	)
 
 	createGroup(flagSet, "matchers", "Matchers",
@@ -258,9 +257,9 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputMatchString, "match-string", "ms", "", "Match response with given string"),
 		flagSet.StringVarP(&options.OutputMatchRegex, "match-regex", "mr", "", "Match response with specific regex"),
 		flagSet.StringVarP(&options.OutputExtractRegex, "extract-regex", "er", "", "Display response content with matched regex"),
-		flagSet.NormalizedStringSliceVarP(&options.OutputMatchFavicon, "match-favicon", "mfc", []string{}, "Match response with specific favicon"),
 		flagSet.StringVarP(&options.OutputMatchLinesCount, "match-line-count", "mlc", "", "Match Response body line count"),
 		flagSet.StringVarP(&options.OutputMatchWordsCount, "match-word-count", "mwc", "", "Match Response body word count"),
+		flagSet.NormalizedStringSliceVarP(&options.OutputMatchFavicon, "match-favicon", "mfc", []string{}, "Match response with specific favicon"),
 	)
 
 	createGroup(flagSet, "filters", "Filters",
@@ -268,9 +267,9 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.OutputFilterContentLength, "filter-length", "fl", "", "Filter response with given content length (-fl 23,33)"),
 		flagSet.StringVarP(&options.OutputFilterString, "filter-string", "fs", "", "Filter response with specific string"),
 		flagSet.StringVarP(&options.OutputFilterRegex, "filter-regex", "fe", "", "Filter response with specific regex"),
-		flagSet.NormalizedStringSliceVarP(&options.OutputFilterFavicon, "filter-favicon", "ffc", []string{}, "Filter response with specific favicon"),
 		flagSet.StringVarP(&options.OutputFilterLinesCount, "filter-line-count", "flc", "", "Filter Response body line count"),
 		flagSet.StringVarP(&options.OutputFilterWordsCount, "filter-word-count", "fwc", "", "Filter Response body word count"),
+		flagSet.NormalizedStringSliceVarP(&options.OutputFilterFavicon, "filter-favicon", "ffc", []string{}, "Filter response with specific favicon"),
 	)
 
 	createGroup(flagSet, "rate-limit", "Rate-Limit",
@@ -279,6 +278,7 @@ func ParseOptions() *Options {
 	)
 
 	createGroup(flagSet, "Misc", "Miscellaneous",
+		flagSet.BoolVar(&options.Favicon, "favicon", false, "Probes for favicon (\"favicon.ico\" as path) and display phythonic hash"),
 		flagSet.BoolVar(&options.TLSGrab, "tls-grab", false, "Perform TLS(SSL) data grabbing"),
 		flagSet.BoolVar(&options.TLSProbe, "tls-probe", false, "Send HTTP probes on the extracted TLS domains"),
 		flagSet.BoolVar(&options.CSPProbe, "csp-probe", false, "Send HTTP probes on the extracted CSP domains"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1198,6 +1198,7 @@ retry:
 		} else {
 			builder.WriteString(faviconMMH3)
 		}
+		builder.WriteRune(']')
 	}
 
 	if scanopts.OutputLinesCount {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -559,7 +559,7 @@ func (r *Runner) RunEnumeration() {
 			if r.options.OutputFilterString != "" && strings.Contains(strings.ToLower(resp.raw), strings.ToLower(r.options.OutputFilterString)) {
 				continue
 			}
-			if len(r.options.filterFavicon) > 0 && slice.UInt32SliceContains(r.options.filterFavicon, resp.FavIconMMH3) {
+			if len(r.options.OutputFilterFavicon) > 0 && stringsutil.EqualFoldAny(resp.FavIconMMH3, r.options.OutputFilterFavicon...) {
 				continue
 			}
 			if len(r.options.matchStatusCode) > 0 && !slice.IntSliceContains(r.options.matchStatusCode, resp.StatusCode) {
@@ -574,7 +574,7 @@ func (r *Runner) RunEnumeration() {
 			if r.options.OutputMatchString != "" && !strings.Contains(strings.ToLower(resp.raw), strings.ToLower(r.options.OutputMatchString)) {
 				continue
 			}
-			if len(r.options.matchFavicon) > 0 && !slice.UInt32SliceContains(r.options.matchFavicon, resp.FavIconMMH3) {
+			if len(r.options.OutputMatchFavicon) > 0 && !stringsutil.EqualFoldAny(resp.FavIconMMH3, r.options.OutputMatchFavicon...) {
 				continue
 			}
 
@@ -1175,15 +1175,14 @@ retry:
 		builder.WriteRune(']')
 	}
 
-	var faviconMMH3 uint32
+	var faviconMMH3 string
 	if scanopts.Favicon {
-		faviconMMH3 = stringz.FaviconHash(resp.Data)
-		faviconMMH3String := fmt.Sprintf("%d", faviconMMH3)
+		faviconMMH3 = fmt.Sprintf("%d", stringz.FaviconHash(resp.Data))
 		builder.WriteString(" [")
 		if !scanopts.OutputWithNoColor {
-			builder.WriteString(aurora.Magenta(faviconMMH3String).String())
+			builder.WriteString(aurora.Magenta(faviconMMH3).String())
 		} else {
-			builder.WriteString(faviconMMH3String)
+			builder.WriteString(faviconMMH3)
 		}
 		builder.WriteRune(']')
 	}
@@ -1343,7 +1342,7 @@ type Result struct {
 	Chain            []httpx.ChainItem   `json:"chain,omitempty" csv:"chain"`
 	FinalURL         string              `json:"final-url,omitempty" csv:"final-url"`
 	Failed           bool                `json:"failed" csv:"failed"`
-	FavIconMMH3      uint32              `json:"favicon-mmh3,omitempty" csv:"favicon-mmh3"`
+	FavIconMMH3      string              `json:"favicon-mmh3,omitempty" csv:"favicon-mmh3"`
 }
 
 // JSON the result


### PR DESCRIPTION
This PR supports favicon extraction with a new flag `-favicon`. If used, the path will be modified to `/favicon.ico`. The resulting hash can be matched or filtered with:
```
-mfc, -match-favicon    Match Favicon hash
-ffc, -filter-favicon    Filter Favicon hash
```