### PR TITLE
Adding support for euc-kr charset

### DIFF
--- a/common/httpx/encodings.go
+++ b/common/httpx/encodings.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
+	"golang.org/x/text/encoding/korean"
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/encoding/traditionalchinese"
 	"golang.org/x/text/transform"
@@ -42,4 +43,9 @@ func Encodebig5(s []byte) ([]byte, error) {
 		return nil, e
 	}
 	return d, nil
+}
+
+func DecodeKorean(s []byte) ([]byte, error) {
+	koreanDecoder := korean.EUCKR.NewDecoder()
+	return koreanDecoder.Bytes(s)
 }


### PR DESCRIPTION
## Description
This PR adds support for `euc-kr` charset

## How to reproduce
```console
$ echo https://weekly.chosun.com | go run . -title -timeout 20

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/              v1.1.6-dev

                projectdiscovery.io

Use with caution. You are responsible for your actions.
Developers assume no liability and are not responsible for any misuse or damage.
https://weekly.chosun.com [주간조선 > 주간조선]
```