### PR TITLE
Adding custom cookies supports in redirects

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -55,6 +55,8 @@ func New(options *Options) (*HTTPX, error) {
 
 	httpx.Options = options
 
+	httpx.Options.parseCustomCookies()
+
 	var retryablehttpOptions = retryablehttp.DefaultOptionsSpraying
 	retryablehttpOptions.Timeout = httpx.Options.Timeout
 	retryablehttpOptions.RetryMax = httpx.Options.RetryMax
@@ -67,6 +69,8 @@ func New(options *Options) (*HTTPX, error) {
 	if httpx.Options.FollowRedirects {
 		// Follow redirects up to a maximum number
 		redirectFunc = func(redirectedRequest *http.Request, previousRequests []*http.Request) error {
+			// add custom cookies if necessary
+			httpx.setCustomCookies(redirectedRequest)
 			if len(previousRequests) >= options.MaxRedirects {
 				// https://github.com/golang/go/issues/10069
 				return http.ErrUseLastResponse
@@ -78,6 +82,9 @@ func New(options *Options) (*HTTPX, error) {
 	if httpx.Options.FollowHostRedirects {
 		// Only follow redirects on the same host up to a maximum number
 		redirectFunc = func(redirectedRequest *http.Request, previousRequests []*http.Request) error {
+			// add custom cookies if necessary
+			httpx.setCustomCookies(redirectedRequest)
+
 			// Check if we get a redirect to a different host
 			var newHost = redirectedRequest.URL.Host
 			var oldHost = previousRequests[0].Host
@@ -322,13 +329,25 @@ func (h *HTTPX) NewRequestWithContext(ctx context.Context, method, targetURL str
 // SetCustomHeaders on the provided request
 func (h *HTTPX) SetCustomHeaders(r *retryablehttp.Request, headers map[string]string) {
 	for name, value := range headers {
-		r.Header.Set(name, value)
-		// host header is particular
-		if strings.EqualFold(name, "host") {
+		switch strings.ToLower(name) {
+		case "host":
 			r.Host = value
+		case "cookie":
+			// cookies are set in the default branch, and reset during the follow redirect flow
+			fallthrough
+		default:
+			r.Header.Set(name, value)
 		}
 	}
 	if h.Options.RandomAgent {
 		r.Header.Set("User-Agent", uarand.GetRandom()) //nolint
+	}
+}
+
+func (httpx *HTTPX) setCustomCookies(req *http.Request) {
+	if httpx.Options.hasCustomCookies() {
+		for _, cookie := range httpx.Options.customCookies {
+			req.AddCookie(cookie)
+		}
 	}
 }

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -1,6 +1,8 @@
 package httpx
 
 import (
+	"net/http"
+	"strings"
 	"time"
 )
 
@@ -37,6 +39,7 @@ type Options struct {
 	MaxResponseBodySizeToRead int64
 	UnsafeURI                 string
 	Resolvers                 []string
+	customCookies             []*http.Cookie
 }
 
 // DefaultOptions contains the default options
@@ -57,4 +60,18 @@ var DefaultOptions = Options{
 	VHostStripHTML:           false,
 	VHostSimilarityRatio:     85,
 	DefaultUserAgent:         "httpx - Open-source project (github.com/projectdiscovery/httpx)",
+}
+
+func (options *Options) parseCustomCookies() {
+	// parse and fill the custom field
+	for k, v := range options.CustomHeaders {
+		if strings.EqualFold(k, "cookie") {
+			req := http.Request{Header: http.Header{"Cookie": []string{v}}}
+			options.customCookies = req.Cookies()
+		}
+	}
+}
+
+func (options *Options) hasCustomCookies() bool {
+	return len(options.customCookies) > 0
 }


### PR DESCRIPTION
## Description
This PR adds support for custom cookies in redirects. Earlier, the custom cookies were sent only on the first http request.