### PR TITLE
Disable static compilation for osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,17 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOMOD=$(GOCMD) mod
 GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
+GOFLAGS := -v 
+LDFLAGS := -s -w
+
+ifneq ($(shell go env GOOS),darwin)
+LDFLAGS := -extldflags "-static"
+endif
     
 all: build
 build:
-		$(GOBUILD) -v -ldflags="-extldflags=-static" -o "httpx" cmd/httpx/httpx.go
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "httpx" cmd/httpx/httpx.go
 test: 
-		$(GOTEST) -v ./...
+	$(GOTEST) $(GOFLAGS) ./...
 tidy:
-		$(GOMOD) tidy
+	$(GOMOD) tidy


### PR DESCRIPTION
## Description
This PR disables static compilation for OSX and enables few compiler flags to reduce binary size and strip debugging symbols.