### PR TITLE
Time based matcher/filter improvements

### DIFF
--- a/cmd/integration-test/http.go
+++ b/cmd/integration-test/http.go
@@ -25,11 +25,16 @@ var httpTestcases = map[string]testutils.TestCase{
 	"Regression test for: https://github.com/projectdiscovery/httpx/issues/414":           &issue414{}, // stream mode with path
 	"Regression test for: https://github.com/projectdiscovery/httpx/issues/433":           &issue433{}, // new line scanning with title flag
 	"Request URI to existing file - https://github.com/projectdiscovery/httpx/issues/480": &issue480{}, // request uri pointing to existing file
+	"Standard HTTP GET Request with match response time":                                  &standardHttpGet{mrt: true, inputValue: "\"<10s\""},
+	"Standard HTTP GET Request with filter response time":                                 &standardHttpGet{frt: true, inputValue: "\">3ms\""},
 }
 
 type standardHttpGet struct {
 	tls            bool
 	unsafe         bool
+	mrt            bool
+	frt            bool
+	inputValue     string
 	stdinPath      string
 	path           string
 	expectedOutput string
@@ -55,7 +60,12 @@ func (h *standardHttpGet) Execute() error {
 	if h.path != "" {
 		extra = append(extra, "-path", "\""+h.path+"\"")
 	}
-
+	if h.mrt {
+		extra = append(extra, "-mrt", h.inputValue)
+	}
+	if h.frt {
+		extra = append(extra, "-frt", h.inputValue)
+	}
 	URL := ts.URL
 	if h.stdinPath != "" {
 		URL += h.stdinPath

--- a/runner/filteroperator.go
+++ b/runner/filteroperator.go
@@ -2,8 +2,8 @@ package runner
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -21,18 +21,21 @@ type FilterOperator struct {
 }
 
 // Parse the given value into operator and value pair
-func (f FilterOperator) Parse(flagValue string) (string, float64, error) {
+func (f FilterOperator) Parse(flagValue string) (string, time.Duration, error) {
 	var (
 		operator string
-		value    float64
+		value    time.Duration
 		err      error
 	)
 	for _, op := range compareOperators {
 		if strings.Contains(flagValue, op) {
-			spl := strings.SplitAfter(flagValue, op)
-			operator = strings.Trim(spl[0], " ")
-			value, err = strconv.ParseFloat(strings.Trim(spl[1], " "), 64)
-			if err != nil {
+			splittedFlagValue := strings.SplitAfter(flagValue, op)
+			operator = strings.Trim(splittedFlagValue[0], " ")
+			timeVal := strings.Trim(splittedFlagValue[1], " ")
+			value, err = time.ParseDuration(timeVal)
+			if err != nil && strings.Contains(err.Error(), "missing unit") {
+				value, _ = time.ParseDuration(fmt.Sprintf("%ss", timeVal))
+			} else if err != nil {
 				return operator, value, fmt.Errorf("invalid value provided for %s", f.flag)
 			}
 			break

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -597,8 +597,7 @@ func (r *Runner) RunEnumeration() {
 			}
 			if len(r.options.OutputFilterCdn) > 0 && stringsutil.EqualFoldAny(resp.CDNName, r.options.OutputFilterCdn...) {
 				continue
-			}
-	
+			}			
 			if r.options.OutputMatchResponseTime != "" {
 				filterOps := FilterOperator{flag: "-mrt, -match-response-time"}
 				operator, value, err := filterOps.Parse(r.options.OutputMatchResponseTime)
@@ -609,22 +608,22 @@ func (r *Runner) RunEnumeration() {
 				switch operator {
 				// take negation of >= and >
 				case greaterThanEq, greaterThan:
-					if respTimeTaken.Seconds() < value {
+					if respTimeTaken < value {
 						continue
 					}
 				// take negation of <= and <
 				case lessThanEq, lessThan:
-					if respTimeTaken.Seconds() > value {
+					if respTimeTaken > value {
 						continue
 					}
 				// take negation of =
 				case equal:
-					if respTimeTaken.Seconds() != value {
+					if respTimeTaken != value {
 						continue
 					}
 				// take negation of !=
 				case notEq:
-					if respTimeTaken.Seconds() == value {
+					if respTimeTaken == value {
 						continue
 					}
 				}
@@ -638,27 +637,27 @@ func (r *Runner) RunEnumeration() {
 				respTimeTaken, _ := time.ParseDuration(resp.ResponseTime)
 				switch operator {
 				case greaterThanEq:
-					if respTimeTaken.Seconds() >= value {
+					if respTimeTaken >= value {
 						continue
 					}
 				case lessThanEq:
-					if respTimeTaken.Seconds() <= value {
+					if respTimeTaken <= value {
 						continue
 					}
 				case equal:
-					if respTimeTaken.Seconds() == value {
+					if respTimeTaken == value {
 						continue
 					}
 				case lessThan:
-					if respTimeTaken.Seconds() < value {
+					if respTimeTaken < value {
 						continue
 					}
 				case greaterThan:
-					if respTimeTaken.Seconds() > value {
+					if respTimeTaken > value {
 						continue
 					}
 				case notEq:
-					if respTimeTaken.Seconds() != value {
+					if respTimeTaken != value {
 						continue
 					}
 				}


### PR DESCRIPTION
This PR adds support to allow the user to specify the time unit along the numeric value for mrt/match-response-time and frt/filter-response-time flags.
Examples:
./httpx -l list.txt -frt '<4s'
./httpx -l list.txt -mrt '<500ms'