### PR TITLE
cname with ports flag bug-fix

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1230,7 +1230,7 @@ retry:
 		builder.WriteString(fmt.Sprintf(" [%s]", ip))
 	}
 
-	ips, cnames, err := getDNSData(hp, domain)
+	ips, cnames, err := getDNSData(hp, URL.Host)
 	if err != nil {
 		ips = append(ips, ip)
 	}


### PR DESCRIPTION
This PR fixes a bug where cname is not displayed with ports flag.
Test: ./httpx -silent -cname -ports 80,443 -l list.txt