### PR TITLE
changed warning to error if the directory does not have write permission

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1400,7 +1400,7 @@ retry:
 		}
 		writeErr := ioutil.WriteFile(responsePath, []byte(respRaw), 0644)
 		if writeErr != nil {
-			gologger.Warning().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
+			gologger.Error().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
 		}
 		if scanopts.StoreChain && resp.HasChain() {
 			domainFile = strings.ReplaceAll(domainFile, ".txt", ".chain.txt")


### PR DESCRIPTION
This PR displays an error if the user attempts to store response in a directory with no write permission.
Test: Create a directory without write permission, run echo 'example.com' | ./httpx -store-response-dir ./no_write_permission_dir/