### PR TITLE
Adding httpx as a library minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,45 @@ https://docs.hackerone.com
 https://support.hackerone.com
 ```
 
+### Using httpx as a library
+`httpx` can be used as a library by creating an instance of the `Option` struct and populating it with the same options that would be specified via CLI. Once validated, the struct should be passed to a runner instance (to close at the end of the program) and the `RunEnumeration` method should be called. Here follows a minimal example of how to do it:
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/projectdiscovery/httpx/runner"
+)
+
+func main() {
+	inputFile := "test.txt"
+	err := os.WriteFile(inputFile, []byte("scanme.sh"), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(inputFile)
+
+	options := runner.Options{
+		Methods:   "GET",
+		InputFile: inputFile,
+	}
+	if err := options.ValidateOptions(); err != nil {
+		log.Fatal(err)
+	}
+
+	httpxRunner, err := runner.New(&options)
+	if err != nil {
+		log.Fatal()
+	}
+	defer httpxRunner.Close()
+
+	httpxRunner.RunEnumeration()
+}
+```
+
 
 # 📋 Notes
 

--- a/cmd/integration-test/integration-test.go
+++ b/cmd/integration-test/integration-test.go
@@ -22,7 +22,8 @@ func main() {
 	failed := aurora.Red("[✘]").String()
 
 	tests := map[string]map[string]testutils.TestCase{
-		"http": httpTestcases,
+		"http":    httpTestcases,
+		"library": libraryTestcases,
 	}
 	for proto, tests := range tests {
 		if protocol == "" || protocol == proto {

--- a/cmd/integration-test/library.go
+++ b/cmd/integration-test/library.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+
+	"github.com/projectdiscovery/httpx/internal/testutils"
+	"github.com/projectdiscovery/httpx/runner"
+)
+
+var libraryTestcases = map[string]testutils.TestCase{
+	"Httpx as library": &httpxLibrary{},
+}
+
+type httpxLibrary struct {
+}
+
+func (h *httpxLibrary) Execute() error {
+	testFile := "test.txt"
+	err := os.WriteFile(testFile, []byte("scanme.sh"), 0644)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(testFile)
+
+	options := runner.Options{
+		Methods:   "GET",
+		InputFile: testFile,
+	}
+	if err := options.ValidateOptions(); err != nil {
+		return err
+	}
+
+	httpxRunner, err := runner.New(&options)
+	if err != nil {
+		return err
+	}
+	defer httpxRunner.Close()
+
+	httpxRunner.RunEnumeration()
+	return nil
+}


### PR DESCRIPTION
## Description
This PR contains updated documentation with a minimal example of how to use `httpx` as a library and an integration test.
The runner API needs a major rework to separate the execution logic from gologger/goflags/CLI dependency. The following changes would be required and will be handled into independent follow-up tickets:
- Input stream via channel
- Adding context support (hence support for cancelation/deadline/timeout)
- Output stream via channel