### PR TITLE
Improving HTML decoding

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -213,6 +213,11 @@ get_response:
 		return nil, closeErr
 	}
 
+	respbody, err = DecodeData(respbody, httpresp.Header)
+	if err != nil && !shouldIgnoreBodyErrors {
+		return nil, closeErr
+	}
+
 	respbodystr := string(respbody)
 
 	// check if we need to strip html

--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -35,51 +35,9 @@ func ExtractTitle(r *Response) (title string) {
 
 	// remove unwanted chars
 	title = strings.TrimSpace(strings.Trim(title, cutset))
-	title = strings.ReplaceAll(title, "\n", "")
-	title = strings.ReplaceAll(title, "\r", "")
+	title = stringsutil.ReplaceAny(title, "\n", "\r")
 
-	// Non UTF-8
-	if contentTypes, ok := r.Headers["Content-Type"]; ok {
-		contentType := strings.ToLower(strings.Join(contentTypes, ";"))
-
-		switch {
-		case stringsutil.ContainsAny(contentType, "charset=gb2312", "charset=gbk"):
-			titleUtf8, err := Decodegbk([]byte(title))
-			if err != nil {
-				return
-			}
-
-			return string(titleUtf8)
-		case stringsutil.ContainsAny(contentType, "euc-kr"):
-			titleUtf8, err := DecodeKorean([]byte(title))
-			if err != nil {
-				return
-			}
-			return string(titleUtf8)
-		}
-
-		// Content-Type from head tag
-		var match = reContentType.FindSubmatch(r.Data)
-		var mcontentType = ""
-		if len(match) != 0 {
-			for i, v := range match {
-				if string(v) != "" && i != 0 {
-					mcontentType = string(v)
-				}
-			}
-			mcontentType = strings.ToLower(mcontentType)
-		}
-		switch {
-		case stringsutil.ContainsAny(mcontentType, "gb2312", "gbk"):
-			titleUtf8, err := Decodegbk([]byte(title))
-			if err != nil {
-				return
-			}
-			return string(titleUtf8)
-		}
-	}
-
-	return //nolint
+	return title
 }
 
 func getTitleWithDom(r *Response) (*html.Node, error) {

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,6 @@ github.com/projectdiscovery/goconfig v0.0.0-20210804090219-f893ccd0c69c/go.mod h
 github.com/projectdiscovery/goflags v0.0.8-0.20220426153734-2ffbfbff923c/go.mod h1:uN+pHMLsWQoiZHUg/l0tqf/VdbX3+ecKfYz/H7b/+NA=
 github.com/projectdiscovery/goflags v0.0.8-0.20220610073650-5d31a8c159e3 h1:2cUSicd6wkd7A3P+tjjAYiPmD99FtWp4k2curJkcrJ0=
 github.com/projectdiscovery/goflags v0.0.8-0.20220610073650-5d31a8c159e3/go.mod h1:Np0EwqmopHDDb1cY4/NEBaC4fornMIWc6dr5yL91kzM=
-github.com/projectdiscovery/goflags v0.0.8 h1:IhTmnEGSKtBHfD23tSwpnzai5CRYfLKVOWlVq9ngYvY=
-github.com/projectdiscovery/goflags v0.0.8/go.mod h1:GDSkWyXa6kfQjpJu10SO64DN8lXuKXVENlBMk8N7H80=
 github.com/projectdiscovery/gologger v1.0.1/go.mod h1:Ok+axMqK53bWNwDSU1nTNwITLYMXMdZtRc8/y1c7sWE=
 github.com/projectdiscovery/gologger v1.1.4 h1:qWxGUq7ukHWT849uGPkagPKF3yBPYAsTtMKunQ8O2VI=
 github.com/projectdiscovery/gologger v1.1.4/go.mod h1:Bhb6Bdx2PV1nMaFLoXNBmHIU85iROS9y1tBuv7T5pMY=


### PR DESCRIPTION
## Description
This PR extends the decoding capability to the whole response body

## Example
```console
$ echo 'https://rce.moe/testgbk.html' | go run . -json -irr | jq

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/              v1.2.2

                projectdiscovery.io

Use with caution. You are responsible for your actions.
Developers assume no liability and are not responsible for any misuse or damage.
{
  "timestamp": "2022-06-26T19:19:58.458757+02:00",
  "hashes": {
    "body-md5": "2ba0178088bb96075ede1bda33bee71c",
    "body-mmh3": "2011569851",
    "body-sha256": "8a15f202e58d863e4e33711d4edc709a68fa79f66fda6691296df8b5bbdb2c26",
    "body-simhash": "16155082011369761733",
    "header-md5": "d7c13438588fff09785e65f3dcfea2e7",
    "header-mmh3": "45123037",
    "header-sha256": "983db9aa9858686cfb662b5126ae8497070f585d0a239bf12d93957541e16f2a",
    "header-simhash": "11012294072176721254"
  },
  "port": "443",
  "url": "https://rce.moe:443/testgbk.html",
  "input": "https://rce.moe/testgbk.html",
  "title": "测试测试测试测试",
  "scheme": "https",
  "webserver": "Vercel",
  "response-body": "<!DOCTYPE html>\n<html lang=\"zh-CN\">\n<head>\n<title>测试测试测试测试</title>\n<meta charset=\"GBK\">\n\n<body>\n<h1>\n测试测试测试测试测试测试测试测试测试测试测试测试测试\n</h1>\n</body>",
  "content-type": "text/html",
  "method": "GET",
  "host": "76.76.21.22",
  "path": "/testgbk.html",
  "response-header": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 175\r\nAccept-Ranges: bytes\r\nAccess-Control-Allow-Origin: *\r\nAge: 20410\r\nCache-Control: public, max-age=0, must-revalidate\r\nContent-Disposition: inline; filename=\"testgbk.html\"\r\nContent-Type: text/html; charset=utf-8\r\nDate: Sun, 26 Jun 2022 17:19:58 GMT\r\nEtag: \"2c7a0e73141df4a888bcf5db9d2c2271\"\r\nServer: Vercel\r\nStrict-Transport-Security: max-age=63072000\r\nX-Vercel-Cache: HIT\r\nX-Vercel-Id: fra1:fra1::qsdnn-1656263998469-9f0ee2367ba4\r\n\r\n",
  "request": "GET /testgbk.html HTTP/1.1\r\nHost: rce.moe\r\nUser-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53\r\nAccept-Charset: utf-8\r\nAccept-Encoding: gzip\r\n\r\n",
  "response-time": "421.019977ms",
  "a": [
    "76.76.21.22"
  ],
  "words": 4,
  "lines": 11,
  "status-code": 200,
  "content-length": 175,
  "failed": false
}
```