### PR TITLE
Removing redundant regex in jarm calculation

### DIFF
--- a/common/hashes/jarmhash.go
+++ b/common/hashes/jarmhash.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/RumbleDiscovery/jarm-go"
-	"github.com/projectdiscovery/httpx/common/regexhelper"
 	"golang.org/x/net/proxy"
 )
 
@@ -20,8 +19,8 @@ var DefualtBackoff = func(r, m int) time.Duration {
 }
 
 type target struct {
-	Host string
-	Port int
+	Host    string
+	Port    int
 	Retries int
 	Backoff func(r, m int) time.Duration
 }
@@ -85,9 +84,5 @@ func Jarm(host string, duration int) string {
 	if t.Port == 0 {
 		t.Port = defaultPort
 	}
-	hash := fingerprint(t, duration)
-	if regexhelper.JarmHashRegex.MatchString(hash) {
-		return ""
-	}
-	return hash
+	return fingerprint(t, duration)
 }

--- a/common/regexhelper/regex.go
+++ b/common/regexhelper/regex.go
@@ -1,7 +1,0 @@
-package regexhelper
-
-import "regexp"
-
-var (
-	JarmHashRegex = regexp.MustCompile("(?m)0{62}")
-)


### PR DESCRIPTION
## Description
This PR removes a redundant regex in the jarm calculation function that was similarly identified at https://github.com/projectdiscovery/tlsx/pull/40#discussion_r910778037