### PR TITLE
feat(runner): expose the method process

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -749,6 +749,14 @@ func (r *Runner) RunEnumeration() {
 	wgoutput.Wait()
 }
 
+func (r *Runner) GetScanOpts() scanOptions {
+	return r.scanopts
+}
+
+func (r *Runner) Process(t string, wg *sizedwaitgroup.SizedWaitGroup, protocol string, scanopts *scanOptions, output chan Result) {
+	r.process(t, wg, r.hp, protocol, scanopts, output)
+}
+
 func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.HTTPX, protocol string, scanopts *scanOptions, output chan Result) {
 	protocols := []string{protocol}
 	if scanopts.NoFallback || protocol == httpx.HTTPandHTTPS {


### PR DESCRIPTION
expose the mothod process to support the pipeline pattern, like https://go.dev/blog/pipelines

this is a example:

```golang
func run(inCh chan string) (outCh chan runner.Result) {
	threadCount := 50
	opt := &runner.Options{
		Methods: "GET",
		Threads: threadCount,
	}
	rr, err := runner.New(opt)
	if err != nil {
		panic(err)
	}
	wg := sizedwaitgroup.New(threadCount)
	scanopts := rr.GetScanOpts()
	outCh = make(chan runner.Result, 1000)
	go func() {
		defer close(outCh)
		for target := range inCh {
			rr.Process(target, &wg, httpx.HTTPorHTTPS, &scanopts, outCh)
		}
		wg.Wait()
	}()
	return outCh
}
```