### PR TITLE
Fixing https with burp

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -172,7 +172,7 @@ get_response:
 
 	var shouldIgnoreErrors, shouldIgnoreBodyErrors bool
 	switch {
-	case h.Options.Unsafe && req.Method == http.MethodHead && !stringsutil.ContainsAny("i/o timeout"):
+	case h.Options.Unsafe && req.Method == http.MethodHead && !stringsutil.ContainsAny(err.Error(), "i/o timeout"):
 		shouldIgnoreErrors = true
 		shouldIgnoreBodyErrors = true
 	}


### PR DESCRIPTION
## Description
This PR attempts to fix #724 by ~~lowering TLS max version to 1.2 when burp proxy is used~~ ignoring tls contextual errors