### PR TITLE
Add delay between making httpx requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ OPTIMIZATIONS:
    -ec, -exclude-cdn                  skip full port scans for CDNs (only checks for 80,443)
    -retries int                       number of retries
    -timeout int                       timeout in seconds (default 5)
-   -delay string                      duration to wait between each connection per thread (eg: 200ms, 1s)
+   -delay duration                      duration to wait between each connection per thread (eg: 200ms, 1s)
    -rsts, -response-size-to-save int  max response size to save in bytes (default 2147483647)
    -rstr, -response-size-to-read int  max response size to read in bytes (default 2147483647)
 ```

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ OPTIMIZATIONS:
    -ec, -exclude-cdn                  skip full port scans for CDNs (only checks for 80,443)
    -retries int                       number of retries
    -timeout int                       timeout in seconds (default 5)
+   -delay string                      duration to wait between each connection per thread (eg: 200ms, 1s)
    -rsts, -response-size-to-save int  max response size to save in bytes (default 2147483647)
    -rstr, -response-size-to-read int  max response size to read in bytes (default 2147483647)
 ```

--- a/runner/options.go
+++ b/runner/options.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
@@ -164,6 +165,7 @@ type Options struct {
 	Retries                   int
 	Threads                   int
 	Timeout                   int
+	Delay                     string
 	filterRegex               *regexp.Regexp
 	matchRegex                *regexp.Regexp
 	VHost                     bool
@@ -396,6 +398,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ExcludeCDN, "exclude-cdn", "ec", false, "skip full port scans for CDNs (only checks for 80,443)"),
 		flagSet.IntVar(&options.Retries, "retries", 0, "number of retries"),
 		flagSet.IntVar(&options.Timeout, "timeout", 5, "timeout in seconds"),
+		flagSet.StringVar(&options.Delay, "delay", "", "duration to wait between each connection per thread (eg: 200ms, 1s)"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToSave, "response-size-to-save", "rsts", math.MaxInt32, "max response size to save in bytes"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToRead, "response-size-to-read", "rstr", math.MaxInt32, "max response size to read in bytes"),
 	)
@@ -548,6 +551,12 @@ func (options *Options) ValidateOptions() error {
 		options.OutputCDN = true
 	}
 
+	if options.Delay != "" {
+		_, err := time.ParseDuration(options.Delay)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing delay %s", options.Delay)
+		}
+	}
 	return nil
 }
 

--- a/runner/options.go
+++ b/runner/options.go
@@ -165,7 +165,7 @@ type Options struct {
 	Retries                   int
 	Threads                   int
 	Timeout                   int
-	Delay                     string
+	Delay                     time.Duration
 	filterRegex               *regexp.Regexp
 	matchRegex                *regexp.Regexp
 	VHost                     bool
@@ -398,7 +398,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ExcludeCDN, "exclude-cdn", "ec", false, "skip full port scans for CDNs (only checks for 80,443)"),
 		flagSet.IntVar(&options.Retries, "retries", 0, "number of retries"),
 		flagSet.IntVar(&options.Timeout, "timeout", 5, "timeout in seconds"),
-		flagSet.StringVar(&options.Delay, "delay", "", "duration between each http request (eg: 200ms, 1s)"),
+		flagSet.DurationVar(&options.Delay, "delay", -1, "duration between each http request (eg: 200ms, 1s)"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToSave, "response-size-to-save", "rsts", math.MaxInt32, "max response size to save in bytes"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToRead, "response-size-to-read", "rstr", math.MaxInt32, "max response size to read in bytes"),
 	)
@@ -551,12 +551,6 @@ func (options *Options) ValidateOptions() error {
 		options.OutputCDN = true
 	}
 
-	if options.Delay != "" {
-		_, err := time.ParseDuration(options.Delay)
-		if err != nil {
-			return errors.Wrapf(err, "error parsing delay %s", options.Delay)
-		}
-	}
 	return nil
 }
 

--- a/runner/options.go
+++ b/runner/options.go
@@ -398,7 +398,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ExcludeCDN, "exclude-cdn", "ec", false, "skip full port scans for CDNs (only checks for 80,443)"),
 		flagSet.IntVar(&options.Retries, "retries", 0, "number of retries"),
 		flagSet.IntVar(&options.Timeout, "timeout", 5, "timeout in seconds"),
-		flagSet.StringVar(&options.Delay, "delay", "", "duration to wait between each connection per thread (eg: 200ms, 1s)"),
+		flagSet.StringVar(&options.Delay, "delay", "", "duration between each http request (eg: 200ms, 1s)"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToSave, "response-size-to-save", "rsts", math.MaxInt32, "max response size to save in bytes"),
 		flagSet.IntVarP(&options.MaxResponseBodySizeToRead, "response-size-to-read", "rstr", math.MaxInt32, "max response size to read in bytes"),
 	)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -854,6 +854,10 @@ func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.
 		if len(customport.Ports) == 0 {
 			for _, method := range scanopts.Methods {
 				for _, prot := range protocols {
+					if r.options.Delay != "" {
+						duration, _ := time.ParseDuration(r.options.Delay)
+						time.Sleep(duration)
+					}
 					wg.Add()
 					go func(target httpx.Target, method, protocol string) {
 						defer wg.Done()
@@ -892,6 +896,10 @@ func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.
 			}
 			for _, wantedProtocol := range wantedProtocols {
 				for _, method := range scanopts.Methods {
+					if r.options.Delay != "" {
+						duration, _ := time.ParseDuration(r.options.Delay)
+						time.Sleep(duration)
+					}
 					wg.Add()
 					go func(port int, target httpx.Target, method, protocol string) {
 						defer wg.Done()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -854,10 +854,8 @@ func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.
 		if len(customport.Ports) == 0 {
 			for _, method := range scanopts.Methods {
 				for _, prot := range protocols {
-					if r.options.Delay != "" {
-						duration, _ := time.ParseDuration(r.options.Delay)
-						time.Sleep(duration)
-					}
+					// sleep for delay time
+					time.Sleep(r.options.Delay)
 					wg.Add()
 					go func(target httpx.Target, method, protocol string) {
 						defer wg.Done()
@@ -896,10 +894,8 @@ func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.
 			}
 			for _, wantedProtocol := range wantedProtocols {
 				for _, method := range scanopts.Methods {
-					if r.options.Delay != "" {
-						duration, _ := time.ParseDuration(r.options.Delay)
-						time.Sleep(duration)
-					}
+					// sleep for delay time
+					time.Sleep(r.options.Delay)
 					wg.Add()
 					go func(port int, target httpx.Target, method, protocol string) {
 						defer wg.Done()


### PR DESCRIPTION
Add delay flag
`-delay string                      duration between each http request (eg: 200ms, 1s)`

- sleep before creating goroutine to make http request
- eg.  
 ``` cat urls.txt | httpx -delay 2s ``` 
     
  ``` cat urls.txt | httpx -delay 2s -port 80,443,8443 ```