### PR TITLE
Fixing content length bytes count

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/corpix/uarand"
 	"github.com/microcosm-cc/bluemonday"
@@ -232,14 +231,14 @@ get_response:
 	// if content length is not defined
 	if resp.ContentLength <= 0 {
 		// check if it's in the header and convert to int
-		if contentLength, ok := resp.Headers["Content-Length"]; ok {
-			contentLengthInt, _ := strconv.Atoi(strings.Join(contentLength, ""))
+		if contentLength, ok := resp.Headers["Content-Length"]; ok && len(contentLength) > 0 {
+			contentLengthInt, _ := strconv.Atoi(contentLength[0])
 			resp.ContentLength = contentLengthInt
 		}
 
 		// if we have a body, then use the number of bytes in the body if the length is still zero
-		if resp.ContentLength <= 0 && len(respbodystr) > 0 {
-			resp.ContentLength = utf8.RuneCountInString(respbodystr)
+		if resp.ContentLength <= 0 && len(respbody) > 0 {
+			resp.ContentLength = len(respbody)
 		}
 	}
 

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -1,0 +1,30 @@
+package httpx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDo(t *testing.T) {
+	ht, err := New(&DefaultOptions)
+	require.Nil(t, err)
+
+	t.Run("content-length in header", func(t *testing.T) {
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://scanme.sh", nil)
+		require.Nil(t, err)
+		resp, err := ht.Do(req, UnsafeOptions{})
+		require.Nil(t, err)
+		require.Equal(t, 2, resp.ContentLength)
+	})
+
+	t.Run("content-length with binary body", func(t *testing.T) {
+		req, err := retryablehttp.NewRequest(http.MethodGet, "https://www.w3schools.com/images/favicon.ico", nil)
+		require.Nil(t, err)
+		resp, err := ht.Do(req, UnsafeOptions{})
+		require.Nil(t, err)
+		require.Equal(t, 318, resp.ContentLength)
+	})
+}


### PR DESCRIPTION
## Description
This PR counts body bytes without performing any decoding

```console
$ echo 'https://ua.oroinc.com/favicon.ico' | go run . -json | jq                                        
...
content_length":476
...
```