### PR TITLE
adds base64 encoding support (#813)

### DIFF
--- a/common/stringz/stringz.go
+++ b/common/stringz/stringz.go
@@ -127,3 +127,8 @@ func InsertInto(s string, interval int, sep rune) string {
 	buffer.WriteRune(sep)
 	return buffer.String()
 }
+
+// Base64 returns base64 of given byte array
+func Base64(bin []byte) string {
+	return base64.StdEncoding.EncodeToString(bin)
+}

--- a/runner/options.go
+++ b/runner/options.go
@@ -54,7 +54,7 @@ type scanOptions struct {
 	OutputWithNoColor         bool
 	OutputMethod              bool
 	ResponseInStdout          bool
-	B64ResponseInStdout       bool
+	Base64ResponseInStdout    bool
 	ChainInStdout             bool
 	TLSProbe                  bool
 	CSPProbe                  bool
@@ -103,7 +103,7 @@ func (s *scanOptions) Clone() *scanOptions {
 		OutputWithNoColor:         s.OutputWithNoColor,
 		OutputMethod:              s.OutputMethod,
 		ResponseInStdout:          s.ResponseInStdout,
-		B64ResponseInStdout:       s.B64ResponseInStdout,
+		Base64ResponseInStdout:    s.Base64ResponseInStdout,
 		ChainInStdout:             s.ChainInStdout,
 		TLSProbe:                  s.TLSProbe,
 		CSPProbe:                  s.CSPProbe,
@@ -186,7 +186,7 @@ type Options struct {
 	OutputServerHeader        bool
 	OutputWebSocket           bool
 	responseInStdout          bool
-	b64responseInStdout       bool
+	base64responseInStdout    bool
 	chainInStdout             bool
 	FollowHostRedirects       bool
 	MaxRedirects              int
@@ -353,7 +353,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.CSVOutput, "csv", false, "store output in csv format"),
 		flagSet.BoolVar(&options.JSONOutput, "json", false, "store output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.responseInStdout, "include-response", "irr", false, "include http request/response in JSON output (-json only)"),
-		flagSet.BoolVarP(&options.b64responseInStdout, "include-response-base64", "irrb", false, "include base64 encoded http request/response in JSON output (-json only)"),
+		flagSet.BoolVarP(&options.base64responseInStdout, "include-response-base64", "irrb", false, "include base64 encoded http request/response in JSON output (-json only)"),
 		flagSet.BoolVar(&options.chainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 	)

--- a/runner/options.go
+++ b/runner/options.go
@@ -54,6 +54,7 @@ type scanOptions struct {
 	OutputWithNoColor         bool
 	OutputMethod              bool
 	ResponseInStdout          bool
+	B64ResponseInStdout       bool
 	ChainInStdout             bool
 	TLSProbe                  bool
 	CSPProbe                  bool
@@ -102,6 +103,7 @@ func (s *scanOptions) Clone() *scanOptions {
 		OutputWithNoColor:         s.OutputWithNoColor,
 		OutputMethod:              s.OutputMethod,
 		ResponseInStdout:          s.ResponseInStdout,
+		B64ResponseInStdout:       s.B64ResponseInStdout,
 		ChainInStdout:             s.ChainInStdout,
 		TLSProbe:                  s.TLSProbe,
 		CSPProbe:                  s.CSPProbe,
@@ -184,6 +186,7 @@ type Options struct {
 	OutputServerHeader        bool
 	OutputWebSocket           bool
 	responseInStdout          bool
+	b64responseInStdout       bool
 	chainInStdout             bool
 	FollowHostRedirects       bool
 	MaxRedirects              int
@@ -350,6 +353,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.CSVOutput, "csv", false, "store output in csv format"),
 		flagSet.BoolVar(&options.JSONOutput, "json", false, "store output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.responseInStdout, "include-response", "irr", false, "include http request/response in JSON output (-json only)"),
+		flagSet.BoolVarP(&options.b64responseInStdout, "include-response-base64", "irrb", false, "include base64 encoded http request/response in JSON output (-json only)"),
 		flagSet.BoolVar(&options.chainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 	)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -217,7 +216,7 @@ func New(options *Options) (*Runner, error) {
 	scanopts.OutputServerHeader = options.OutputServerHeader
 	scanopts.OutputWithNoColor = options.NoColor
 	scanopts.ResponseInStdout = options.responseInStdout
-	scanopts.B64ResponseInStdout = options.b64responseInStdout
+	scanopts.Base64ResponseInStdout = options.base64responseInStdout
 	scanopts.ChainInStdout = options.chainInStdout
 	scanopts.OutputWebSocket = options.OutputWebSocket
 	scanopts.TLSProbe = options.TLSProbe
@@ -1294,11 +1293,11 @@ retry:
 		request = string(requestDump)
 		responseHeader = normalizeHeaders(resp.Headers)
 		rawResponseHeader = resp.RawHeaders
-	} else if scanopts.B64ResponseInStdout {
-		serverResponseRaw = b64(resp.Data)
-		request = b64(requestDump)
+	} else if scanopts.Base64ResponseInStdout {
+		serverResponseRaw = stringz.Base64(resp.Data)
+		request = stringz.Base64(requestDump)
 		responseHeader = normalizeHeaders(resp.Headers)
-		rawResponseHeader = b64([]byte(resp.RawHeaders))
+		rawResponseHeader = stringz.Base64([]byte(resp.RawHeaders))
 	}
 
 	// check for virtual host
@@ -1777,9 +1776,4 @@ func normalizeHeaders(headers map[string][]string) map[string]interface{} {
 		normalized[strings.ReplaceAll(strings.ToLower(k), "-", "_")] = strings.Join(v, ", ")
 	}
 	return normalized
-}
-
-// b64 returns base64 of given byte array
-func b64(bin []byte) string {
-	return base64.StdEncoding.EncodeToString(bin)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -216,6 +217,7 @@ func New(options *Options) (*Runner, error) {
 	scanopts.OutputServerHeader = options.OutputServerHeader
 	scanopts.OutputWithNoColor = options.NoColor
 	scanopts.ResponseInStdout = options.responseInStdout
+	scanopts.B64ResponseInStdout = options.b64responseInStdout
 	scanopts.ChainInStdout = options.chainInStdout
 	scanopts.OutputWebSocket = options.OutputWebSocket
 	scanopts.TLSProbe = options.TLSProbe
@@ -1292,6 +1294,11 @@ retry:
 		request = string(requestDump)
 		responseHeader = normalizeHeaders(resp.Headers)
 		rawResponseHeader = resp.RawHeaders
+	} else if scanopts.B64ResponseInStdout {
+		serverResponseRaw = b64(resp.Data)
+		request = b64(requestDump)
+		responseHeader = normalizeHeaders(resp.Headers)
+		rawResponseHeader = b64([]byte(resp.RawHeaders))
 	}
 
 	// check for virtual host
@@ -1770,4 +1777,9 @@ func normalizeHeaders(headers map[string][]string) map[string]interface{} {
 		normalized[strings.ReplaceAll(strings.ToLower(k), "-", "_")] = strings.Join(v, ", ")
 	}
 	return normalized
+}
+
+// b64 returns base64 of given byte array
+func b64(bin []byte) string {
+	return base64.StdEncoding.EncodeToString(bin)
 }


### PR DESCRIPTION
# Description

- Adds base64 encoding to  request and response in json mode.
 
```sh
   -irrb, -include-response-base64   include base64 encoded http request/response in JSON output (-json only)
```
- Below JSON Fields are base64 encoded
  -  request // entire request
  - raw_header // response headers
  - body. // response body

### Run Below Command to Verify

```sh
echo "projectdiscovery.io/xxx" | ./httpx -irrb -json | jq .
```


closes #813 




