### PR TITLE
Enforcing wildcard check to prefix only

### DIFF
--- a/cmd/functional-test/testcases.txt
+++ b/cmd/functional-test/testcases.txt
@@ -15,3 +15,4 @@ scanme.sh {{binary}} -silent -x all
 scanme.sh {{binary}} -silent -body 'a=b'
 scanme.sh {{binary}} -silent -exclude-cdn
 scanme.sh {{binary}} -silent -ports https:443
+https://scanme.sh?a=1*1 {{binary}} -silent

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -964,13 +964,14 @@ func (r *Runner) targets(hp *httpx.HTTPX, target string) chan httpx.Target {
 	results := make(chan httpx.Target)
 	go func() {
 		defer close(results)
+
+		target = strings.TrimSpace(target)
+
 		switch {
-		case strings.ContainsAny(target, "*") || strings.HasPrefix(target, "."):
+		case stringsutil.HasPrefixAny(target, "*", "."):
 			// A valid target does not contain:
-			// *
-			// spaces
 			// trim * and/or . (prefix) from the target to return the domain instead of wilcard
-			target = strings.TrimPrefix(strings.Trim(target, "*"), ".")
+			target = stringsutil.TrimPrefixAny(target, "*", ".")
 			if !r.testAndSet(target) {
 				return
 			}


### PR DESCRIPTION
```console
$ echo "https://scanme.sh/?blabla=666*666" | go run .
...
https://scanme.sh/?blabla=666*666
```