### PR TITLE
Update README with correct help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 # Usage
 
 ```sh
-httpx -h
+httpx --help
 ```
 
 This will display help for the tool. Here are all the switches it supports.


### PR DESCRIPTION
This updates the README file with the `--help` flag instead of `-h`. The `-h` flag is used for headers.