### PR TITLE
clarify README -ms flag to be case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ MATCHERS:
    -mlc, -match-line-count string     match response body with specified line count (-mlc 423,532)
    -mwc, -match-word-count string     match response body with specified word count (-mwc 43,55)
    -mfc, -match-favicon string[]      match response with specified favicon hash (-mfc 1494302000)
-   -ms, -match-string string          match response with specified string (not case sensitive) (-ms admin)
+   -ms, -match-string string          match response with specified string (case insensitive) (-ms admin)
    -mr, -match-regex string           match response with specified regex (-mr admin)
    -mcdn, -match-cdn string[]         match host with specified cdn provider (oracle, google, azure, cloudflare, cloudfront, fastly, incapsula, leaseweb, akamai, sucuri)
    -mrt, -match-response-time string  match response with specified response time in seconds (-mrt '< 1')

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ MATCHERS:
    -mlc, -match-line-count string     match response body with specified line count (-mlc 423,532)
    -mwc, -match-word-count string     match response body with specified word count (-mwc 43,55)
    -mfc, -match-favicon string[]      match response with specified favicon hash (-mfc 1494302000)
-   -ms, -match-string string          match response with specified string (-ms admin)
+   -ms, -match-string string          match response with specified string (not case sensitive) (-ms admin)
    -mr, -match-regex string           match response with specified regex (-mr admin)
    -mcdn, -match-cdn string[]         match host with specified cdn provider (oracle, google, azure, cloudflare, cloudfront, fastly, incapsula, leaseweb, akamai, sucuri)
    -mrt, -match-response-time string  match response with specified response time in seconds (-mrt '< 1')


### PR DESCRIPTION
Using -ms match string with uppercase characters was returning false positive matches for me. I realize the -mr match regex can be used to match casing, but the clarity for -ms would have saved me a lot of time here. I believe lowercase matching occurs here https://github.com/projectdiscovery/httpx/blob/954cbe6e95a1cafadf116cd37946ae8b73135091/runner/runner.go#L729