### PR TITLE
Improving split with URLs

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1009,7 +1009,7 @@ func (r *Runner) targets(hp *httpx.HTTPX, target string) chan httpx.Target {
 			for _, ip := range ips {
 				results <- httpx.Target{Host: target, CustomIP: ip}
 			}
-		case strings.Index(target, ",") > 0:
+		case !stringsutil.HasPrefixAny(target, "http://", "https://") && stringsutil.ContainsAny(target, ","):
 			idxComma := strings.Index(target, ",")
 			results <- httpx.Target{Host: target[idxComma+1:], CustomHost: target[:idxComma]}
 		default:

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -141,3 +141,20 @@ func TestRunner_countTargetFromRawTarget(t *testing.T) {
 	got = r.countTargetFromRawTarget(input)
 	require.Equal(t, expected, got, "got wrong output")
 }
+
+func TestRunner_urlWithComma_targets(t *testing.T) {
+	options := &Options{}
+	r, err := New(options)
+	require.Nil(t, err, "could not create httpx runner")
+	input := []string{"http://scanme.sh?a=1,2"}
+	expected := []httpx.Target{{
+		Host: "http://scanme.sh?a=1,2",
+	}}
+	got := []httpx.Target{}
+	for _, inp := range input {
+		for target := range r.targets(r.hp, inp) {
+			got = append(got, target)
+		}
+	}
+	require.ElementsMatch(t, expected, got, "could not exepcted output")
+}


### PR DESCRIPTION
Closes #1002 

Note: implemented only for URL from a file as the tool is widely adopted with comma-separated targets via stdin/CLI argument

```console
$ cat list.txt
http://192.168.1.2?a=b,c
$ httpx -v -l test.txt
...
[DBG] Failed 'http://192.168.1.2?a=b,c': GET http://192.168.1.2?a=b,c giving up after 1 attempts: Get "http://192.168.1.2?a=b,c": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```