### PR TITLE
Issue 1019 dsl var missing

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -31,7 +31,6 @@ import (
 	"github.com/projectdiscovery/httpx/common/hashes/jarm"
 	"github.com/projectdiscovery/mapcidr/asn"
 	errorutil "github.com/projectdiscovery/utils/errors"
-	mapsutil "github.com/projectdiscovery/utils/maps"
 
 	"github.com/bluele/gcache"
 	"github.com/logrusorgru/aurora"
@@ -663,11 +662,11 @@ func (r *Runner) RunEnumeration() {
 					gologger.Warning().Msgf("Could not decode response: %s\n", err)
 					continue
 				}
-
-				flatMap := make(map[string]any)
-				mapsutil.Walk(rawMap, func(k string, v any) {
-					flatMap[k] = v
-				})
+				dslVars, _ := dslVariables()
+				flatMap := make(map[string]interface{})
+				for _, v := range dslVars {
+					flatMap[v] = rawMap[v]
+				}
 
 				if r.options.OutputMatchCondition != "" {
 					res, err := dsl.EvalExpr(r.options.OutputMatchCondition, flatMap)
@@ -1305,7 +1304,7 @@ retry:
 	var request string
 	var rawResponseHeader string
 	var responseHeader map[string]interface{}
-	if scanopts.ResponseInStdout {
+	if scanopts.ResponseInStdout || r.options.OutputMatchCondition != "" || r.options.OutputFilterCondition != "" {
 		serverResponseRaw = string(resp.Data)
 		request = string(requestDump)
 		responseHeader = normalizeHeaders(resp.Headers)


### PR DESCRIPTION
Fixed bug of all dsl variables not accessiable
```
eg:
❯ echo example.com | ./httpx -mdc "contains(body, 'example')" -silent
https://example.com

❯ echo example.com | ./httpx -fdc "contains(body, 'example')" -silent

```

Note:
- If `-mdc` and `-fdc` flag is passed, it will include body in json output similar to `-irr`.
- As `-mdc` and `-fdc` need body content to check. 
```
❯ echo example.com | ./httpx -mdc "contains(body, 'example')" -silent -json | jq
{
  "timestamp": "2023-03-30T12:18:32.170904523+05:30",
  "hash": {
    ...
   body": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" conte....
   ....
}
```