### PR TITLE
fix ignoring http path with port switch

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -986,7 +986,7 @@ func (r *Runner) process(t string, wg *sizedwaitgroup.SizedWaitGroup, hp *httpx.
 							gologger.Warning().Msgf("failed to update port of %v got %v", target.Host, err)
 						} else {
 							urlx.UpdatePort(fmt.Sprint(port))
-							target.Host = urlx.Host
+							target.Host = urlx.String()
 						}
 						result := r.analyze(hp, protocol, target, method, t, scanopts)
 						output <- result


### PR DESCRIPTION
#1090 Ignoring the http path when using the p switch 

```console
echo http://127.0.0.1/NO-PATH/ | ./httpx -duc -debug-req -nfs -p http:80

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

		projectdiscovery.io

[INF] Dumped HTTP request for http://127.0.0.1:80/NO-PATH/

GET /NO-PATH/ HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; en-US) AppleWebKit/532.8 (KHTML, like Gecko) Chrome/4.0.302.2 Safari/532.8
Accept-Charset: utf-8
Accept-Encoding: gzip
```