### PR TITLE
Don't write missing screenshots to index file

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -683,7 +683,7 @@ func (r *Runner) RunEnumeration() {
 				indexData := fmt.Sprintf("%s %s (%d %s)\n", resp.StoredResponsePath, resp.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 				_, _ = indexFile.WriteString(indexData)
 			}
-			if indexScreenshotFile != nil {
+			if indexScreenshotFile != nil && resp.ScreenshotPath != "" {
 				indexData := fmt.Sprintf("%s %s (%d %s)\n", resp.ScreenshotPath, resp.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 				_, _ = indexScreenshotFile.WriteString(indexData)
 			}
@@ -1680,12 +1680,12 @@ retry:
 		headlessBody    string
 	)
 	if scanopts.Screenshot {
-		screenshotPath = fileutilz.AbsPathOrDefault(filepath.Join(screenshotBaseDir, screenshotResponseFile))
 		var err error
 		screenshotBytes, headlessBody, err = r.browser.ScreenshotWithBody(fullURL, r.hp.Options.Timeout)
 		if err != nil {
 			gologger.Warning().Msgf("Could not take screenshot '%s': %s", fullURL, err)
 		} else {
+			screenshotPath = fileutilz.AbsPathOrDefault(filepath.Join(screenshotBaseDir, screenshotResponseFile))
 			_ = fileutil.CreateFolder(screenshotBaseDir)
 			err := os.WriteFile(screenshotPath, screenshotBytes, 0644)
 			if err != nil {


### PR DESCRIPTION
The screenshots in index_screenshot.txt do not correspond with the files in the screenshot directory. The error causing this issue is that `ScreenshotWithBody` returns `context deadline exceeded` for the following URLs:

1. https://www.maglaj.ba/ba/investitori.php?id=%22%3E%3Cimg%20src=x%20onerror=alert(1);%3E
2. https://maglaj.ba/ba/investitori.php?id=%22%3E%3Cimg%20src=x%20onerror=alert(1);%3E

And we are initializing the `screenshotPath` regardless of whether there is an error and returning it. Thus, we write it to the `index_screenshot.txt` file. There are two issues, actually:

1. Screenshot mismatch, as mentioned in the beginning
2. context deadline exceeded: we're getting an error when trying to capture a screenshot of the page with `ScreenshotWithBody`- the root cause.

To repro the issue(from #1125):
```sh
subfinder -d maglaj.ba | httpx -silent -path "/ba/investitori.php?id=%22%3E%3Cimg%20src=x%20onerror=alert(1);%3E" -mc 200 -follow-redirects -screenshot
```

I was able to fix the first issue by avoiding the initialization of `screenshotPath` beforehand. I'll further investigate the root cause.