### PR TITLE
delete duplicate onresult option

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1744,9 +1744,6 @@ retry:
 		ScreenshotPath:     screenshotPath,
 		HeadlessBody:       headlessBody,
 	}
-	if r.options.OnResult != nil {
-		r.options.OnResult(result)
-	}
 	return result
 }
 


### PR DESCRIPTION
The problem occurs because of a duplicate code here. The r.options.OnResult callback is called twice.

https://github.com/projectdiscovery/httpx/blob/main/runner/runner.go#L1747-L1749

https://github.com/projectdiscovery/httpx/blob/main/runner/runner.go#L667-L669

closes #1184