### PR TITLE
Make output response fields public

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -190,8 +190,8 @@ type Options struct {
 	NoColor                   bool
 	OutputServerHeader        bool
 	OutputWebSocket           bool
-	responseInStdout          bool
-	base64responseInStdout    bool
+	ResponseInStdout          bool
+	Base64responseInStdout    bool
 	chainInStdout             bool
 	FollowHostRedirects       bool
 	MaxRedirects              int
@@ -376,8 +376,8 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.CSVOutput, "csv", false, "store output in csv format"),
 		flagSet.StringVarP(&options.CSVOutputEncoding, "csv-output-encoding", "csvo", "", "define output encoding"),
 		flagSet.BoolVar(&options.JSONOutput, "json", false, "store output in JSONL(ines) format"),
-		flagSet.BoolVarP(&options.responseInStdout, "include-response", "irr", false, "include http request/response in JSON output (-json only)"),
-		flagSet.BoolVarP(&options.base64responseInStdout, "include-response-base64", "irrb", false, "include base64 encoded http request/response in JSON output (-json only)"),
+		flagSet.BoolVarP(&options.ResponseInStdout, "include-response", "irr", false, "include http request/response in JSON output (-json only)"),
+		flagSet.BoolVarP(&options.Base64responseInStdout, "include-response-base64", "irrb", false, "include base64 encoded http request/response in JSON output (-json only)"),
 		flagSet.BoolVar(&options.chainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 	)


### PR DESCRIPTION
Make output response fields public so they can be specified if httpx used as a library.

These field are directly set by CLI flags but it's impossible to specify them if httpx used as a Go library. This PR should fix this.