### PR TITLE
add config flag

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -276,6 +276,7 @@ type Options struct {
 // ParseOptions parses the command line options for application
 func ParseOptions() *Options {
 	options := &Options{}
+	var cfgFile string
 
 	flagSet := goflags.NewFlagSet()
 	flagSet.SetDescription(`httpx is a fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library.`)
@@ -383,6 +384,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",
+		flagSet.StringVar(&cfgFile, "config", "", "path to the httpx configuration file (default $HOME/.config/httpx/config.yaml)"),
 		flagSet.StringSliceVarP(&options.Resolvers, "resolvers", "r", nil, "list of custom resolver (file or comma separated)", goflags.NormalizedStringSliceOptions),
 		flagSet.Var(&options.Allow, "allow", "allowed list of IP/CIDR's to process (file or comma separated)"),
 		flagSet.Var(&options.Deny, "deny", "denied list of IP/CIDR's to process (file or comma separated)"),
@@ -434,6 +436,16 @@ func ParseOptions() *Options {
 	)
 
 	_ = flagSet.Parse()
+
+	if cfgFile != "" {
+		if !fileutil.FileExists(cfgFile) {
+			gologger.Fatal().Msgf("given config file '%s' does not exist", cfgFile)
+		}
+		// merge config file with flags
+		if err := flagSet.MergeConfigFile(cfgFile); err != nil {
+			gologger.Fatal().Msgf("Could not read config: %s\n", err)
+		}
+	}
 
 	if options.HealthCheck {
 		gologger.Print().Msgf("%s\n", DoHealthCheck(options, flagSet))


### PR DESCRIPTION
This PR adds `-config` flag. Closes #1102.

```console
$ go run .

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.3 (latest)

$ go run . -config custom-config.yaml 

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.3 (latest)
https://scanme.sh [444bcb3a3fcf8389296c49467f27e1d6]

$ cat custom-config.yaml 
# httpx config file
# generated by https://github.com/projectdiscovery/goflags

# input file containing list of hosts to process
#list: 

# file containing raw request
#request: 

# input target host(s) to probe
target: [scanme.sh]

# display response status-code
#status-code: false

# display response content-length
#content-length: false

# display response content-type
#content-type: false

# display response redirect location
#location: false

# display mmh3 hash for '/favicon.ico' file
#favicon: false

# display response body hash (supported: md5,mmh3,simhash,sha1,sha256,sha512)
hash: md5

# display jarm fingerprint hash
#jarm: false

# display response time
#response-time: false

# display response body line count
#line-count: false

# display response body word count
#word-count: false

# display page title
#title: false

# display server name
#web-server: false

# display technology in use based on wappalyzer dataset
#tech-detect: false

# display http request method
#method: false

# display server using websocket
#websocket: false

# display host ip
#ip: false

# display host cname
#cname: false

# display host asn information
#asn: false

# display cdn in use
#cdn: false

# display probe status
#probe: false

# enable saving screenshot of the page using headless browser
#screenshot: false

# enable using local installed chrome for screenshot
#system-chrome: false

# match response with specified status code (-mc 200,302)
#match-code: 

# match response with specified content length (-ml 100,102)
#match-length: 

# match response body with specified line count (-mlc 423,532)
#match-line-count: 

# match response body with specified word count (-mwc 43,55)
#match-word-count: 

# match response with specified favicon hash (-mfc 1494302000)
#match-favicon: []

# match response with specified string (-ms admin)
#match-string: 

# match response with specified regex (-mr admin)
#match-regex: 

# match host with specified cdn provider (fastly, google, leaseweb, stackpath, cloudfront)
#match-cdn: []

# match response with specified response time in seconds (-mrt '< 1')
#match-response-time: 

# match response with dsl expression condition
#match-condition: 

# display response content with matched regex
#extract-regex: []

# display response content matched by a pre-defined regex (url,ipv4,mail)
#extract-preset: []

# filter response with specified status code (-fc 403,401)
#filter-code: 

# filter response with specified content length (-fl 23,33)
#filter-length: 

# filter response body with specified line count (-flc 423,532)
#filter-line-count: 

# filter response body with specified word count (-fwc 423,532)
#filter-word-count: 

# filter response with specified favicon hash (-mfc 1494302000)
#filter-favicon: []

# filter response with specified string (-fs admin)
#filter-string: 

# filter response with specified regex (-fe admin)
#filter-regex: 

# filter host with specified cdn provider (fastly, google, leaseweb, stackpath, cloudfront)
#filter-cdn: []

# filter response with specified response time in seconds (-frt '> 1')
#filter-response-time: 

# filter response with dsl expression condition
#filter-condition: 

# number of threads to use
#threads: 50

# maximum requests to send per second
#rate-limit: 150

# maximum number of requests to send per minute
#rate-limit-minute: 0

# probe all the ips associated with same host
#probe-all-ips: false

# ports to probe (nmap syntax: eg http:1,2-10,11,https:80)
#ports: Custom Ports

# path or list of paths to probe (comma-separated, file)
#path: 

# send http probes on the extracted tls domains (dns_name)
#tls-probe: false

# send http probes on the extracted csp domains
#csp-probe: false

# perform tls(ssl) data grabbing
#tls-grab: false

# probe and display server supporting http1.1 pipeline
#pipeline: false

# probe and display server supporting http2
#http2: false

# probe and display server supporting vhost
#vhost: false

# list json output field keys name that support dsl matcher/filter
#list-dsl-variables: false

# update httpx to latest version
#update: false

# disable automatic httpx update check
#disable-update-check: false

# file to write output results
#output: 

# filename to write output results in all formats
#output-all: false

# store http response to output directory
#store-response: false

# store http response to custom directory
#store-response-dir: 

# store output in csv format
#csv: false

# define output encoding
#csv-output-encoding: 

# store output in jsonl(ines) format
#json: false

# include http request/response in json output (-json only)
#include-response: false

# include base64 encoded http request/response in json output (-json only)
#include-response-base64: false

# include redirect http chain in json output (-json only)
#include-chain: false

# include http redirect chain in responses (-sr only)
#store-chain: false

# list of custom resolver (file or comma separated)
#resolvers: []

# allowed list of ip/cidr's to process (file or comma separated)
#allow: Custom Global List

# denied list of ip/cidr's to process (file or comma separated)
#deny: Custom Global List

# custom tls sni name
#sni-name: 

# enable random user-agent to use
#random-agent: true

# custom http headers to send with request
#header: Custom Global Headers

# http proxy to use (eg http://127.0.0.1:8080)
#proxy: 

# send raw requests skipping golang normalization
#unsafe: false

# resume scan using resume.cfg
#resume: false

# follow http redirects
#follow-redirects: false

# max number of redirects to follow per host
#max-redirects: 10

# follow redirects on the same host
#follow-host-redirects: false

# get a list of vhosts as input
#vhost-input: false

# request methods to probe, use 'all' to probe all http methods
#x: 

# post body to include in http request
#body: 

# stream mode - start elaborating input targets without sorting
#stream: false

# disable dedupe input items (only used with stream mode)
#skip-dedupe: false

# leave default http/https ports in host header (eg. http://host:80 - https://host:443
#leave-default-ports: false

# use ztls library with autofallback to standard one for tls13
#ztls: false

# avoid decoding body
#no-decode: false

# disable stdin processing
#no-stdin: false

# run diagnostic check up
#hc: false

# display request/response content in cli
#debug: false

# display request content in cli
#debug-req: false

# display response content in cli
#debug-resp: false

# display httpx version
#version: false

# display scan statistic
#stats: false

# optional httpx memory profile dump file
#profile-mem: 

# silent mode
#silent: false

# verbose mode
#verbose: false

# number of seconds to wait between showing a statistics update (default: 5)
#stats-interval: 0

# disable colors in cli output
#no-color: false

# display both probed protocol (https and http)
#no-fallback: false

# probe with protocol scheme specified in input 
#no-fallback-scheme: false

# max error count per host before skipping remaining path/s
#max-host-error: 30

# skip full port scans for cdns (only checks for 80,443)
#exclude-cdn: false

# number of retries
#retries: 0

# timeout in seconds
#timeout: 10

# duration between each http request (eg: 200ms, 1s)
#delay: 

# max response size to save in bytes
#response-size-to-save: 2147483647

# max response size to read in bytes
```