### PR TITLE
 Adding two new filters && Output optimization

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -159,6 +159,8 @@ type Options struct {
 	OutputMatchStatusCode     string
 	OutputMatchContentLength  string
 	OutputFilterStatusCode    string
+	OutputFilterTitle         goflags.StringSlice
+	OutputFilterServerHeader  goflags.StringSlice
 	OutputFilterErrorPage     bool
 	OutputFilterContentLength string
 	InputRawRequest           string
@@ -337,6 +339,8 @@ func ParseOptions() *Options {
 
 	flagSet.CreateGroup("filters", "Filters",
 		flagSet.StringVarP(&options.OutputFilterStatusCode, "filter-code", "fc", "", "filter response with specified status code (-fc 403,401)"),
+		flagSet.StringSliceVarP(&options.OutputFilterTitle, "filter-title", "ftt", nil, "filter response body with specified html title (-ftt WAF,Firewall)", goflags.NormalizedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.OutputFilterServerHeader, "filter-server", "fsh", nil, "filter response with specified server header (-fsh cloudflare,stgw)", goflags.NormalizedStringSliceOptions),
 		flagSet.BoolVarP(&options.OutputFilterErrorPage, "filter-error-page", "fep", false, "filter response with ML based error page detection"),
 		flagSet.StringVarP(&options.OutputFilterContentLength, "filter-length", "fl", "", "filter response with specified content length (-fl 23,33)"),
 		flagSet.StringVarP(&options.OutputFilterLinesCount, "filter-line-count", "flc", "", "filter response body with specified line count (-flc 423,532)"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1505,6 +1505,7 @@ retry:
 	title := httpx.ExtractTitle(resp)
 	if scanopts.OutputTitle {
 		builder.WriteString(" [")
+		title = strings.ReplaceAll(title, "\n", "")
 		if !scanopts.OutputWithNoColor {
 			builder.WriteString(aurora.Cyan(title).String())
 		} else {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -804,6 +804,12 @@ func (r *Runner) RunEnumeration() {
 			if r.options.OutputFilterString != "" && strings.Contains(strings.ToLower(resp.Raw), strings.ToLower(r.options.OutputFilterString)) {
 				continue
 			}
+			if len(r.options.OutputFilterTitle) > 0 && stringsutil.EqualFoldAny(resp.Title, r.options.OutputFilterTitle...) {
+				continue
+			}
+			if len(r.options.OutputFilterServerHeader) > 0 && stringsutil.EqualFoldAny(resp.WebServer, r.options.OutputFilterServerHeader...) {
+				continue
+			}
 			if len(r.options.OutputFilterFavicon) > 0 && stringsutil.EqualFoldAny(resp.FavIconMMH3, r.options.OutputFilterFavicon...) {
 				continue
 			}


### PR DESCRIPTION
If someone adds '\n' within the HTML title tag, it could lead to abnormal line outputs.

```
https://xxxxx [301] [301
Moved Permanently] [nginx/1.23.1] [111.203.158.238]
```

Using regular expressions for replacement wasn't convenient enough, so I added two filters.
- Response server header
- HTML titlez

Before

```
-fe '(Server: (Tengine|stgw))|(<title>(WAF|Firewall)</title>)'
```

After

```
-fsh Tengine,stgw -ftt WAF,Firewall
```