### PR TITLE
Implementation of feature request #1330

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -85,6 +85,8 @@ type ScanOptions struct {
 	Hashes                    string
 	Screenshot                bool
 	UseInstalledChrome        bool
+	NoScreenshotBytes         bool
+	NoHeadlessBody            bool
 	DisableStdini             bool
 }
 
@@ -133,6 +135,8 @@ func (s *ScanOptions) Clone() *ScanOptions {
 		OutputWordsCount:          s.OutputWordsCount,
 		Hashes:                    s.Hashes,
 		Screenshot:                s.Screenshot,
+		NoScreenshotBytes:         s.NoScreenshotBytes,
+		NoHeadlessBody:            s.NoHeadlessBody,
 		UseInstalledChrome:        s.UseInstalledChrome,
 	}
 }
@@ -273,6 +277,8 @@ type Options struct {
 	UseInstalledChrome bool
 	TlsImpersonate     bool
 	DisableStdin       bool
+	NoScreenshotBytes  bool
+	NoHeadlessBody     bool
 }
 
 // ParseOptions parses the command line options for application
@@ -315,6 +321,8 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("headless", "Headless",
 		flagSet.BoolVarP(&options.Screenshot, "screenshot", "ss", false, "enable saving screenshot of the page using headless browser"),
 		flagSet.BoolVar(&options.UseInstalledChrome, "system-chrome", false, "enable using local installed chrome for screenshot"),
+		flagSet.BoolVarP(&options.NoScreenshotBytes, "exclude-screenshot-bytes", "esb", false, "enable excluding screenshot bytes from json output"),
+		flagSet.BoolVarP(&options.NoHeadlessBody, "exclude-headless-body", "ehb", false, "enable excluding headless header from json output"),
 	)
 
 	flagSet.CreateGroup("matchers", "Matchers",

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -245,6 +245,8 @@ func New(options *Options) (*Runner, error) {
 		runner.browser = browser
 	}
 	scanopts.Screenshot = options.Screenshot
+	scanopts.NoScreenshotBytes = options.NoScreenshotBytes
+	scanopts.NoHeadlessBody = options.NoHeadlessBody
 	scanopts.UseInstalledChrome = options.UseInstalledChrome
 
 	if options.OutputExtractRegexs != nil {
@@ -1876,6 +1878,12 @@ retry:
 			if err != nil {
 				gologger.Error().Msgf("Could not write screenshot at path '%s', to disk: %s", screenshotPath, err)
 			}
+		}
+		if scanopts.NoScreenshotBytes {
+			screenshotBytes = []byte{}
+		}
+		if scanopts.NoHeadlessBody {
+			headlessBody = ""
 		}
 	}
 


### PR DESCRIPTION
Hi,
This PR add the -esb and -ehb options to exclude the screenshot_bytes and/or the headless_body from the JSON output.