### PR TITLE
Modify redirect storage

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -75,6 +75,17 @@ func New(options *Options) (*HTTPX, error) {
 		redirectFunc = func(redirectedRequest *http.Request, previousRequests []*http.Request) error {
 			// add custom cookies if necessary
 			httpx.setCustomCookies(redirectedRequest)
+
+			location := redirectedRequest.Response.Header.Get("Location")
+			hsts := redirectedRequest.Response.Header.Get("Strict-Transport-Security")
+			url, err := redirectedRequest.URL.Parse(location)
+			if err != nil {
+			} else {
+				if url.Scheme == "http" && hsts != "" {
+					url.Scheme = "https"
+				}
+			}
+			redirectedRequest.URL = url
 			if len(previousRequests) >= options.MaxRedirects {
 				// https://github.com/golang/go/issues/10069
 				return http.ErrUseLastResponse

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -75,17 +75,6 @@ func New(options *Options) (*HTTPX, error) {
 		redirectFunc = func(redirectedRequest *http.Request, previousRequests []*http.Request) error {
 			// add custom cookies if necessary
 			httpx.setCustomCookies(redirectedRequest)
-
-			location := redirectedRequest.Response.Header.Get("Location")
-			hsts := redirectedRequest.Response.Header.Get("Strict-Transport-Security")
-			url, err := redirectedRequest.URL.Parse(location)
-			if err != nil {
-			} else {
-				if url.Scheme == "http" && hsts != "" {
-					url.Scheme = "https"
-				}
-			}
-			redirectedRequest.URL = url
 			if len(previousRequests) >= options.MaxRedirects {
 				// https://github.com/golang/go/issues/10069
 				return http.ErrUseLastResponse

--- a/common/httpx/response.go
+++ b/common/httpx/response.go
@@ -69,9 +69,13 @@ func (r *Response) GetChainStatusCodes() []int {
 // GetChain dump the whole redirect chain as string
 func (r *Response) GetChain() string {
 	var respchain strings.Builder
-	for _, chainItem := range r.Chain {
-		respchain.Write(chainItem.Request)
-		respchain.Write(chainItem.Response)
+	for counter, chainItem := range r.Chain {
+		if counter != 0 {
+			respchain.Write(chainItem.Request)
+		}
+		if counter < len(r.Chain)-1 {
+			respchain.Write(chainItem.Response)
+		}
 	}
 	return respchain.String()
 }

--- a/runner/options.go
+++ b/runner/options.go
@@ -85,6 +85,8 @@ type ScanOptions struct {
 	Hashes                    string
 	Screenshot                bool
 	UseInstalledChrome        bool
+	NoScreenshotBytes         bool
+	NoHeadlessBody            bool
 	DisableStdini             bool
 }
 
@@ -133,6 +135,8 @@ func (s *ScanOptions) Clone() *ScanOptions {
 		OutputWordsCount:          s.OutputWordsCount,
 		Hashes:                    s.Hashes,
 		Screenshot:                s.Screenshot,
+		NoScreenshotBytes:         s.NoScreenshotBytes,
+		NoHeadlessBody:            s.NoHeadlessBody,
 		UseInstalledChrome:        s.UseInstalledChrome,
 	}
 }
@@ -273,6 +277,8 @@ type Options struct {
 	UseInstalledChrome bool
 	TlsImpersonate     bool
 	DisableStdin       bool
+	NoScreenshotBytes  bool
+	NoHeadlessBody     bool
 }
 
 // ParseOptions parses the command line options for application
@@ -315,6 +321,8 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("headless", "Headless",
 		flagSet.BoolVarP(&options.Screenshot, "screenshot", "ss", false, "enable saving screenshot of the page using headless browser"),
 		flagSet.BoolVar(&options.UseInstalledChrome, "system-chrome", false, "enable using local installed chrome for screenshot"),
+		flagSet.BoolVarP(&options.NoScreenshotBytes, "exclude-screenshot-bytes", "esb", false, "enable excluding screenshot bytes from json output"),
+		flagSet.BoolVarP(&options.NoHeadlessBody, "exclude-headless-body", "ehb", false, "enable excluding headless header from json output"),
 	)
 
 	flagSet.CreateGroup("matchers", "Matchers",

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -245,6 +245,8 @@ func New(options *Options) (*Runner, error) {
 		runner.browser = browser
 	}
 	scanopts.Screenshot = options.Screenshot
+	scanopts.NoScreenshotBytes = options.NoScreenshotBytes
+	scanopts.NoHeadlessBody = options.NoHeadlessBody
 	scanopts.UseInstalledChrome = options.UseInstalledChrome
 
 	if options.OutputExtractRegexs != nil {
@@ -1876,6 +1878,12 @@ retry:
 			if err != nil {
 				gologger.Error().Msgf("Could not write screenshot at path '%s', to disk: %s", screenshotPath, err)
 			}
+		}
+		if scanopts.NoScreenshotBytes {
+			screenshotBytes = []byte{}
+		}
+		if scanopts.NoHeadlessBody {
+			headlessBody = ""
 		}
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1795,7 +1795,6 @@ retry:
 		}
 		data := append([]byte(fullURL), append([]byte("\n\n"), reqRaw...)...)
 		if scanopts.StoreChain && resp.HasChain() {
-			resp.GetChain()
 			data = append(data, append([]byte("\n"), []byte(resp.GetChain())...)...)
 		}
 		data = append(data, append([]byte("\n"), respRaw...)...)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1804,12 +1804,6 @@ retry:
 		if writeErr != nil {
 			gologger.Error().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
 		}
-		if scanopts.StoreChain && resp.HasChain() {
-			//writeErr := os.WriteFile(responsePath, []byte(resp.GetChain()), 0644)
-			if writeErr != nil {
-				gologger.Warning().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
-			}
-		}
 	}
 
 	parsed, err := r.parseURL(fullURL)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1794,6 +1794,10 @@ retry:
 			respRaw = respRaw[:scanopts.MaxResponseBodySizeToSave]
 		}
 		data := append([]byte(fullURL), append([]byte("\n\n"), reqRaw...)...)
+		if scanopts.StoreChain && resp.HasChain() {
+			resp.GetChain()
+			data = append(data, append([]byte("\n"), []byte(resp.GetChain())...)...)
+		}
 		data = append(data, append([]byte("\n"), respRaw...)...)
 		_ = fileutil.CreateFolder(responseBaseDir)
 		writeErr := os.WriteFile(responsePath, data, 0644)
@@ -1801,7 +1805,7 @@ retry:
 			gologger.Error().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
 		}
 		if scanopts.StoreChain && resp.HasChain() {
-			writeErr := os.WriteFile(responsePath, []byte(resp.GetChain()), 0644)
+			//writeErr := os.WriteFile(responsePath, []byte(resp.GetChain()), 0644)
 			if writeErr != nil {
 				gologger.Warning().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
 			}


### PR DESCRIPTION
If the option "fr" and "sr/srd" are used most of the time (not completely verified that if it is always) only the redirect headers are stored but not the final response content. 

This change corrects that, so that all the redirect requests and responses as well as the final response body is stored in the output. 