### PR TITLE
remove fullurl from req-res

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1791,8 +1791,8 @@ retry:
 		if len(respRaw) > scanopts.MaxResponseBodySizeToSave {
 			respRaw = respRaw[:scanopts.MaxResponseBodySizeToSave]
 		}
-		data := append([]byte(fullURL), append([]byte("\n\n"), reqRaw...)...)
-		data = append(data, append([]byte("\n"), respRaw...)...)
+		data := reqRaw
+		data = append(data, respRaw...)
 		_ = fileutil.CreateFolder(responseBaseDir)
 		writeErr := os.WriteFile(responsePath, data, 0644)
 		if writeErr != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1793,6 +1793,8 @@ retry:
 		}
 		data := reqRaw
 		data = append(data, respRaw...)
+		data = append(data, []byte("\n\n\n")...)
+		data = append(data, []byte(fullURL)...)
 		_ = fileutil.CreateFolder(responseBaseDir)
 		writeErr := os.WriteFile(responsePath, data, 0644)
 		if writeErr != nil {


### PR DESCRIPTION
This PR removes fullURL storage when using `-store-response`.  Possible solution to #1317.

before:
```console
$ cat test.txt
https://pastebin.com/raw/TYsVwM0n

GET /raw/TYsVwM0n HTTP/1.1
Host: pastebin.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0
Accept-Charset: utf-8
Accept-Encoding: gzip


HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Age: 45
Cache-Control: public, max-age=1801
Cf-Cache-Status: HIT
Cf-Ray: 7ff435236ac3286e-OTP
Content-Type: text/plain; charset=utf-8
Date: Thu, 31 Aug 2023 09:22:11 GMT
Last-Modified: Thu, 31 Aug 2023 09:21:26 GMT
Server: cloudflare
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 1;mode=block

38
line1
this is a line containing HTTP/1.1 FOO BAR
line3
0

$ cat main.go
package main

import (
	"bufio"
	"bytes"
	"fmt"
	"net/http"
	"os"
)

func main() {
	data, _ := os.ReadFile("test.txt")
	br := bufio.NewReader(bytes.NewReader(data))
	req, err := http.ReadRequest(br)
	fmt.Println(err, req)
	fmt.Println()
	res, err := http.ReadResponse(br, req)
	fmt.Println(err, res)
}

$ go run .
malformed HTTP request "https://pastebin.com/raw/TYsVwM0n" <nil>

malformed HTTP response "" <nil>
```

after:
```console
$ cat test.txt
GET /raw/TYsVwM0n HTTP/1.1
Host: pastebin.com
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0
Accept-Charset: utf-8
Accept-Encoding: gzip

HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Age: 45
Cache-Control: public, max-age=1801
Cf-Cache-Status: HIT
Cf-Ray: 7ff435236ac3286e-OTP
Content-Type: text/plain; charset=utf-8
Date: Thu, 31 Aug 2023 09:22:11 GMT
Last-Modified: Thu, 31 Aug 2023 09:21:26 GMT
Server: cloudflare
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Xss-Protection: 1;mode=block

38
line1
this is a line containing HTTP/1.1 FOO BAR
line3
0

$ cat main.go
package main

import (
	"bufio"
	"bytes"
	"fmt"
	"net/http"
	"os"
)

func main() {
	data, _ := os.ReadFile("test.txt")
	br := bufio.NewReader(bytes.NewReader(data))
	req, err := http.ReadRequest(br)
	fmt.Println(err, req)
	fmt.Println()
	res, err := http.ReadResponse(br, req)
	fmt.Println(err, res)
}

$ go run .
<nil> &{GET /raw/TYsVwM0n HTTP/1.1 1 1 map[Accept-Charset:[utf-8] Accept-Encoding:[gzip] User-Agent:[Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0]] {} <nil> 0 [] false pastebin.com map[] map[] <nil> map[]  /raw/TYsVwM0n <nil> <nil> <nil> <nil>}

<nil> &{200 OK 200 HTTP/1.1 1 1 map[Age:[45] Cache-Control:[public, max-age=1801] Cf-Cache-Status:[HIT] Cf-Ray:[7ff435236ac3286e-OTP] Content-Type:[text/plain; charset=utf-8] Date:[Thu, 31 Aug 2023 09:22:11 GMT] Last-Modified:[Thu, 31 Aug 2023 09:21:26 GMT] Server:[cloudflare] Vary:[Accept-Encoding] X-Content-Type-Options:[nosniff] X-Frame-Options:[DENY] X-Xss-Protection:[1;mode=block]] 0x400006a240 -1 [chunked] true false map[] 0x400012a000 <nil>}
```