### PR TITLE
Modified storing of redirect response chain

### DIFF
--- a/common/httpx/response.go
+++ b/common/httpx/response.go
@@ -69,9 +69,13 @@ func (r *Response) GetChainStatusCodes() []int {
 // GetChain dump the whole redirect chain as string
 func (r *Response) GetChain() string {
 	var respchain strings.Builder
-	for _, chainItem := range r.Chain {
-		respchain.Write(chainItem.Request)
-		respchain.Write(chainItem.Response)
+	for counter, chainItem := range r.Chain {
+		if counter != 0 {
+			respchain.Write(chainItem.Request)
+		}
+		if counter < len(r.Chain)-1 {
+			respchain.Write(chainItem.Response)
+		}
 	}
 	return respchain.String()
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1819,17 +1819,14 @@ retry:
 			respRaw = respRaw[:scanopts.MaxResponseBodySizeToSave]
 		}
 		data := append([]byte(fullURL), append([]byte("\n\n"), reqRaw...)...)
+		if scanopts.StoreChain && resp.HasChain() {
+			data = append(data, append([]byte("\n"), []byte(resp.GetChain())...)...)
+		}
 		data = append(data, append([]byte("\n"), respRaw...)...)
 		_ = fileutil.CreateFolder(responseBaseDir)
 		writeErr := os.WriteFile(responsePath, data, 0644)
 		if writeErr != nil {
 			gologger.Error().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
-		}
-		if scanopts.StoreChain && resp.HasChain() {
-			writeErr := os.WriteFile(responsePath, []byte(resp.GetChain()), 0644)
-			if writeErr != nil {
-				gologger.Warning().Msgf("Could not write response at path '%s', to disk: %s", responsePath, writeErr)
-			}
 		}
 	}
 


### PR DESCRIPTION
Modified storing of redirect response chain to output all redirects and responses.

Previously responses (especially the final get response body) was not stored always (or even never). 
Modified it that if follow redirect is specified not only the request/responses of the redirects but also the final response body is stored. 