### PR TITLE
fix favicon host header issue

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1932,6 +1932,7 @@ func (r *Runner) handleFaviconHash(hp *httpx.HTTPX, req *retryablehttp.Request, 
 		}
 		if URL.IsAbs() {
 			req.SetURL(URL)
+			req.Host = URL.Host
 			faviconPath = ""
 		} else {
 			faviconPath = URL.String()


### PR DESCRIPTION
Closes #1333.

before:
```console
$ go run . -u https://spirit.com.au/ -favicon

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
https://spirit.com.au/
```

after:
```console
$ go run . -u https://spirit.com.au/ -favicon

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
https://spirit.com.au/ [1668213002]
```