### PR TITLE
fix screenshot path issue

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1899,7 +1899,7 @@ retry:
 		ExtractRegex:       extractRegex,
 		StoredResponsePath: responsePath,
 		ScreenshotBytes:    screenshotBytes,
-		ScreenshotPath:     screenshotPath,
+		ScreenshotPath:     filepath.Join(hostFilename, screenshotResponseFile),
 		HeadlessBody:       headlessBody,
 		KnowledgeBase: map[string]interface{}{
 			"PageType": r.errorPageClassifier.Classify(respData),


### PR DESCRIPTION
Closes #1328.

before:
```console
$ go run . -u projectdiscovery.io -screenshot

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
https://scanme.sh
```
screenshot:
<img width="754" alt="image" src="https://github.com/projectdiscovery/httpx/assets/65292895/d78e4fed-9e95-4c89-a027-8bbd9ac1988e">


after:
```console
$ go run . -u projectdiscovery.io -screenshot

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
https://scanme.sh
```
screenshot:
<img width="749" alt="image" src="https://github.com/projectdiscovery/httpx/assets/65292895/b3cbce04-5ade-4ce3-9805-448d51ee940c">


P.S. To simulate the WSL case, I ran httpx on Guest-OS (Debian, Docker) and opened the `screenshot.html` in the Host-OS(Darwin). 