### PR TITLE
fix filter and match

### DIFF
--- a/runner/types.go
+++ b/runner/types.go
@@ -134,24 +134,7 @@ func resultToMap(resp Result) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error decoding: %v", err)
 	}
-	return flatten(m), nil
-}
-
-// mapsutil.Flatten w/o separator
-func flatten(m map[string]any) map[string]any {
-	o := make(map[string]any)
-	for k, v := range m {
-		switch child := v.(type) {
-		case map[string]any:
-			nm := flatten(child)
-			for nk, nv := range nm {
-				o[nk] = nv
-			}
-		default:
-			o[k] = v
-		}
-	}
-	return o
+	return m, nil
 }
 
 var (


### PR DESCRIPTION
Closes #1345.

```console
$ go run httpx.go -u scanme.sh  -mdc 'contains(header,"text/plain")'

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
https://scanme.sh


$ go run httpx.go -u scanme.sh  -fdc 'contains(header,"text/plain")'

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.4 (latest)
```