### PR TITLE
fix minor screenshot issues

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -586,12 +586,13 @@ func (r *Runner) RunEnumeration() {
 		if err := os.MkdirAll(responseFolder, os.ModePerm); err != nil {
 			gologger.Fatal().Msgf("Could not create output response directory '%s': %s\n", r.options.StoreResponseDir, err)
 		}
-		// screenshot folder
-		if r.options.Screenshot {
-			screenshotFolder := filepath.Join(r.options.StoreResponseDir, "screenshot")
-			if err := os.MkdirAll(screenshotFolder, os.ModePerm); err != nil {
-				gologger.Fatal().Msgf("Could not create output screenshot directory '%s': %s\n", r.options.StoreResponseDir, err)
-			}
+	}
+
+	// screenshot folder
+	if r.options.Screenshot {
+		screenshotFolder := filepath.Join(r.options.StoreResponseDir, "screenshot")
+		if err := os.MkdirAll(screenshotFolder, os.ModePerm); err != nil {
+			gologger.Fatal().Msgf("Could not create output screenshot directory '%s': %s\n", r.options.StoreResponseDir, err)
 		}
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -587,9 +587,11 @@ func (r *Runner) RunEnumeration() {
 			gologger.Fatal().Msgf("Could not create output response directory '%s': %s\n", r.options.StoreResponseDir, err)
 		}
 		// screenshot folder
-		screenshotFolder := filepath.Join(r.options.StoreResponseDir, "screenshot")
-		if err := os.MkdirAll(screenshotFolder, os.ModePerm); err != nil {
-			gologger.Fatal().Msgf("Could not create output screenshot directory '%s': %s\n", r.options.StoreResponseDir, err)
+		if r.options.Screenshot {
+			screenshotFolder := filepath.Join(r.options.StoreResponseDir, "screenshot")
+			if err := os.MkdirAll(screenshotFolder, os.ModePerm); err != nil {
+				gologger.Fatal().Msgf("Could not create output screenshot directory '%s': %s\n", r.options.StoreResponseDir, err)
+			}
 		}
 	}
 
@@ -736,8 +738,8 @@ func (r *Runner) RunEnumeration() {
 				indexData := fmt.Sprintf("%s %s (%d %s)\n", resp.StoredResponsePath, resp.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 				_, _ = indexFile.WriteString(indexData)
 			}
-			if indexScreenshotFile != nil && resp.ScreenshotPath != "" {
-				indexData := fmt.Sprintf("%s %s (%d %s)\n", resp.ScreenshotPath, resp.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
+			if indexScreenshotFile != nil && resp.ScreenshotPathRel != "" {
+				indexData := fmt.Sprintf("%s %s (%d %s)\n", resp.ScreenshotPathRel, resp.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 				_, _ = indexScreenshotFile.WriteString(indexData)
 			}
 
@@ -1522,9 +1524,9 @@ retry:
 		responseHeaders    map[string]interface{}
 	)
 
-    if scanopts.ResponseHeadersInStdout {
-       responseHeaders = normalizeHeaders(resp.Headers)
-    }
+	if scanopts.ResponseHeadersInStdout {
+		responseHeaders = normalizeHeaders(resp.Headers)
+	}
 
 	respData := string(resp.Data)
 	if r.options.NoDecode {
@@ -1809,7 +1811,7 @@ retry:
 	responseBaseDir := filepath.Join(domainResponseBaseDir, hostFilename)
 	screenshotBaseDir := filepath.Join(domainScreenshotBaseDir, hostFilename)
 
-	var responsePath, screenshotPath string
+	var responsePath, screenshotPath, screenshotPathRel string
 	// store response
 	if scanopts.StoreResponse || scanopts.StoreChain {
 		responsePath = fileutilz.AbsPathOrDefault(filepath.Join(responseBaseDir, domainResponseFile))
@@ -1874,6 +1876,7 @@ retry:
 			gologger.Warning().Msgf("Could not take screenshot '%s': %s", fullURL, err)
 		} else {
 			screenshotPath = fileutilz.AbsPathOrDefault(filepath.Join(screenshotBaseDir, screenshotResponseFile))
+			screenshotPathRel = filepath.Join(hostFilename, screenshotResponseFile)
 			_ = fileutil.CreateFolder(screenshotBaseDir)
 			err := os.WriteFile(screenshotPath, screenshotBytes, 0644)
 			if err != nil {
@@ -1930,7 +1933,8 @@ retry:
 		ExtractRegex:       extractRegex,
 		StoredResponsePath: responsePath,
 		ScreenshotBytes:    screenshotBytes,
-		ScreenshotPath:     filepath.Join(hostFilename, screenshotResponseFile),
+		ScreenshotPath:     screenshotPath,
+		ScreenshotPathRel:  screenshotPathRel,
 		HeadlessBody:       headlessBody,
 		KnowledgeBase: map[string]interface{}{
 			"PageType": r.errorPageClassifier.Classify(respData),

--- a/runner/types.go
+++ b/runner/types.go
@@ -83,6 +83,7 @@ type Result struct {
 	ScreenshotBytes    []byte                 `json:"screenshot_bytes,omitempty" csv:"screenshot_bytes"`
 	StoredResponsePath string                 `json:"stored_response_path,omitempty" csv:"stored_response_path"`
 	ScreenshotPath     string                 `json:"screenshot_path,omitempty" csv:"screenshot_path"`
+	ScreenshotPathRel  string                 `json:"screenshot_path_rel,omitempty" csv:"screenshot_path_rel"`
 	KnowledgeBase      map[string]interface{} `json:"knowledgebase,omitempty" csv:"knowledgebase"`
 }
 

--- a/static/html-summary.html
+++ b/static/html-summary.html
@@ -119,8 +119,8 @@
                     </ul>
                 </td>
                 <td style="padding: 10px; border: 1px solid black">
-                    <a href="{{.ScreenshotPath | safeURL}}" target="_blank">
-                        <img src="{{.ScreenshotPath | safeURL}}" alt="Screenshot" style="width: 400px; height: 300px" />
+                    <a href="{{.ScreenshotPathRel | safeURL}}" target="_blank">
+                        <img src="{{.ScreenshotPathRel | safeURL}}" alt="Screenshot" style="width: 400px; height: 300px" />
                     </a>
                 </td>
             </tr>


### PR DESCRIPTION
Closes #1352.

```console
$ go run . -u scanme.sh -sr
$ tree output
output
└── response
    ├── index.txt
    └── scanme.sh
        └── 3f31e99f37ddb963c46ea3b9eed80d4bae8cde21.txt

2 directories, 2 files
```

```console
$ go run . -u scanme.sh -json | jq .

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.5 (latest)
{
  "timestamp": "2023-09-12T12:30:59.651904263Z",
  "hash": {
    "body_md5": "444bcb3a3fcf8389296c49467f27e1d6",
    "body_mmh3": "-2088429648",
    "body_sha256": "2689367b205c16ce32ed4200942b8b8b1e262dfc70d9bc9fbc77c49699a4f1df",
    "body_simhash": "590632390773907579",
    "header_md5": "9e781576d6ff509ed58774e9934043e4",
    "header_mmh3": "-761354649",
    "header_sha256": "e274b92c0edbd52f920ac12e94681c0ef849aae8faa70ec6d8c5786ca66c25bd",
    "header_simhash": "9814105681235261821"
  },
  "port": "443",
  "url": "https://scanme.sh",
  "input": "scanme.sh",
  "scheme": "https",
  "content_type": "text/plain",
  "method": "GET",
  "host": "128.199.158.128",
  "path": "/",
  "time": "1.521285542s",
  "a": [
    "128.199.158.128",
    "2400:6180:0:d0::91:1001"
  ],
  "words": 1,
  "lines": 1,
  "status_code": 200,
  "content_length": 2,
  "failed": false,
  "knowledgebase": {
    "PageType": "nonerror"
  }
}
```