### PR TITLE
increase timeout for a page lifecycle event

### DIFF
--- a/runner/headless.go
+++ b/runner/headless.go
@@ -102,7 +102,7 @@ func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration) ([]byte,
 		return nil, "", err
 	}
 
-	page.Timeout(timeout).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
+	page.Timeout(5 * time.Second).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
 
 	if err := page.WaitLoad(); err != nil {
 		return nil, "", err

--- a/runner/headless.go
+++ b/runner/headless.go
@@ -102,7 +102,7 @@ func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration) ([]byte,
 		return nil, "", err
 	}
 
-	page.Timeout(3 * time.Second).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
+	page.Timeout(timeout).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
 
 	if err := page.WaitLoad(); err != nil {
 		return nil, "", err

--- a/runner/headless.go
+++ b/runner/headless.go
@@ -102,7 +102,7 @@ func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration) ([]byte,
 		return nil, "", err
 	}
 
-	page.Timeout(2 * time.Second).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
+	page.Timeout(3 * time.Second).WaitNavigation(proto.PageLifecycleEventNameFirstMeaningfulPaint)()
 
 	if err := page.WaitLoad(); err != nil {
 		return nil, "", err


### PR DESCRIPTION
```console
$ go run . -u https://www.bugcrowd.com/ --screenshot

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.6 (latest)
https://www.bugcrowd.com/

$ tree output/
output/
├── response
│   ├── index.txt
│   └── www.bugcrowd.com
│       └── 4d59c7e03dae25c5c51064db16f8042a768d4e86.txt
└── screenshot
    ├── index_screenshot.txt
    ├── screenshot.html
    └── www.bugcrowd.com
        └── 4d59c7e03dae25c5c51064db16f8042a768d4e86.png

4 directories, 5 files
```
Closes #1428