### PR TITLE
Remove additional `-U` for `apk` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 RUN go build ./cmd/httpx
 
 FROM alpine:3.18.2
-RUN apk -U upgrade --no-cache \
+RUN apk upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates chromium
 COPY --from=builder /app/httpx /usr/local/bin/
 


### PR DESCRIPTION
There is no need to use `-U` with `--no-cache` when using `apk` on Alpine Linux, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest, without temporary files remain in the image.