### PR TITLE
introduce `-exclude` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,7 @@ OPTIMIZATIONS:
    -nf, -no-fallback                  display both probed protocol (HTTPS and HTTP)
    -nfs, -no-fallback-scheme          probe with protocol scheme specified in input 
    -maxhr, -max-host-error int        max error count per host before skipping remaining path/s (default 30)
-   -ec, -exclude-cdn                  skip full port scans for CDN/WAF (only checks for 80,443)
-   -eph, -exclude-private-hosts       skip any hosts which have a private ip address
+   -e, -exclude string[]              exclude host matching specified filter (comma separated)
    -retries int                       number of retries
    -timeout int                       timeout in seconds (default 10)
    -delay value                       duration between each http request (eg: 200ms, 1s) (default -1ns)

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ OPTIMIZATIONS:
    -nf, -no-fallback                  display both probed protocol (HTTPS and HTTP)
    -nfs, -no-fallback-scheme          probe with protocol scheme specified in input 
    -maxhr, -max-host-error int        max error count per host before skipping remaining path/s (default 30)
-   -e, -exclude string[]              exclude host matching specified filter (comma separated)
+   -e, -exclude string[]              exclude host matching specified filter ('cdn', 'private-ips', cidr, ip, regex)
    -retries int                       number of retries
    -timeout int                       timeout in seconds (default 10)
    -delay value                       duration between each http request (eg: 200ms, 1s) (default -1ns)

--- a/cmd/functional-test/testcases.txt
+++ b/cmd/functional-test/testcases.txt
@@ -13,7 +13,7 @@ scanme.sh {{binary}} -silent -tls-grab
 scanme.sh {{binary}} -silent -unsafe
 scanme.sh {{binary}} -silent -x all
 scanme.sh {{binary}} -silent -body 'a=b'
-scanme.sh {{binary}} -silent -exclude-cdn
+scanme.sh {{binary}} -silent -exclude cdn
 scanme.sh {{binary}} -silent -ports https:443
 scanme.sh {{binary}} -silent -ztls
 scanme.sh {{binary}} -silent -jarm

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -8,14 +8,13 @@ import (
 
 // Options contains configuration options for the client
 type Options struct {
-	RandomAgent         bool
-	DefaultUserAgent    string
-	HTTPProxy           string
-	SocksProxy          string
-	Threads             int
-	CdnCheck            bool
-	ExcludeCdn          bool
-	ExcludePrivateHosts bool
+	RandomAgent      bool
+	DefaultUserAgent string
+	HTTPProxy        string
+	SocksProxy       string
+	Threads          int
+	CdnCheck         bool
+	ExcludeCdn       bool
 	// Timeout is the maximum time to wait for the request
 	Timeout time.Duration
 	// RetryMax is the maximum number of retries
@@ -49,15 +48,14 @@ type Options struct {
 
 // DefaultOptions contains the default options
 var DefaultOptions = Options{
-	RandomAgent:         true,
-	Threads:             25,
-	Timeout:             30 * time.Second,
-	RetryMax:            5,
-	MaxRedirects:        10,
-	Unsafe:              false,
-	CdnCheck:            true,
-	ExcludeCdn:          false,
-	ExcludePrivateHosts: false,
+	RandomAgent:  true,
+	Threads:      25,
+	Timeout:      30 * time.Second,
+	RetryMax:     5,
+	MaxRedirects: 10,
+	Unsafe:       false,
+	CdnCheck:     true,
+	ExcludeCdn:   false,
 	// VHOSTs options
 	VHostIgnoreStatusCode:    false,
 	VHostIgnoreContentLength: true,

--- a/runner/options.go
+++ b/runner/options.go
@@ -78,7 +78,6 @@ type ScanOptions struct {
 	OutputExtractRegex        string
 	extractRegexps            map[string]*regexp.Regexp
 	ExcludeCDN                bool
-	ExcludePrivateHosts       bool
 	HostMaxErrors             int
 	ProbeAllIPS               bool
 	Favicon                   bool
@@ -456,7 +455,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.NoFallback, "no-fallback", "nf", false, "display both probed protocol (HTTPS and HTTP)"),
 		flagSet.BoolVarP(&options.NoFallbackScheme, "no-fallback-scheme", "nfs", false, "probe with protocol scheme specified in input "),
 		flagSet.IntVarP(&options.HostMaxErrors, "max-host-error", "maxhr", 30, "max error count per host before skipping remaining path/s"),
-		flagSet.StringSliceVarP(&options.Exclude, "exclude", "e", nil, "exclude host matching specified filter (comma separated)", goflags.CommaSeparatedStringSliceOptions),
+		flagSet.StringSliceVarP(&options.Exclude, "exclude", "e", nil, "exclude host matching specified filter ('cdn', 'private-ips', cidr, ip, regex)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.IntVar(&options.Retries, "retries", 0, "number of retries"),
 		flagSet.IntVar(&options.Timeout, "timeout", 10, "timeout in seconds"),
 		flagSet.DurationVar(&options.Delay, "delay", -1, "duration between each http request (eg: 200ms, 1s)"),

--- a/runner/options.go
+++ b/runner/options.go
@@ -243,8 +243,7 @@ type Options struct {
 	Probe                     bool
 	Resume                    bool
 	resumeCfg                 *ResumeCfg
-	ExcludeCDN                bool
-	ExcludePrivateHosts       bool
+	Exclude                   goflags.StringSlice
 	HostMaxErrors             int
 	Stream                    bool
 	SkipDedupe                bool
@@ -457,8 +456,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.NoFallback, "no-fallback", "nf", false, "display both probed protocol (HTTPS and HTTP)"),
 		flagSet.BoolVarP(&options.NoFallbackScheme, "no-fallback-scheme", "nfs", false, "probe with protocol scheme specified in input "),
 		flagSet.IntVarP(&options.HostMaxErrors, "max-host-error", "maxhr", 30, "max error count per host before skipping remaining path/s"),
-		flagSet.BoolVarP(&options.ExcludeCDN, "exclude-cdn", "ec", false, "skip full port scans for CDN/WAF (only checks for 80,443)"),
-		flagSet.BoolVarP(&options.ExcludePrivateHosts, "exclude-private-hosts", "eph", false, "skip any hosts which have a private ip address"),
+		flagSet.StringSliceVarP(&options.Exclude, "exclude", "e", nil, "exclude host matching specified filter (comma separated)", goflags.CommaSeparatedStringSliceOptions),
 		flagSet.IntVar(&options.Retries, "retries", 0, "number of retries"),
 		flagSet.IntVar(&options.Timeout, "timeout", 10, "timeout in seconds"),
 		flagSet.DurationVar(&options.Delay, "delay", -1, "duration between each http request (eg: 200ms, 1s)"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -77,6 +77,11 @@ type Runner struct {
 	wappalyzer          *wappalyzer.Wappalyze
 	scanopts            ScanOptions
 	hm                  *hybrid.HybridMap
+	excludeHosts        map[string]struct{}
+	excludePorts        map[string]struct{}
+	excludeRegexes      map[string]struct{}
+	excludeCdn          bool
+	excludePrivateHosts bool
 	stats               clistats.StatisticsClient
 	ratelimiter         ratelimit.Limiter
 	HostErrorsCache     gcache.Cache[string, int]
@@ -114,6 +119,33 @@ func New(options *Options) (*Runner, error) {
 		os.RemoveAll(filepath.Join(options.StoreResponseDir, "screenshot", "index_screenshot.txt"))
 	}
 
+	runner.excludeHosts = make(map[string]struct{})
+	runner.excludePorts = make(map[string]struct{})
+	runner.excludeRegexes = make(map[string]struct{})
+	for _, exclude := range options.Exclude {
+		switch {
+		case exclude == "cdn":
+			runner.excludeCdn = true
+		case exclude == "private-ips":
+			runner.excludePrivateHosts = true
+		case iputil.IsCIDR(exclude):
+			ips := expandCIDRInputValue(exclude)
+			runner.addHosts(ips)
+		case asn.IsASN(exclude):
+			ips := expandASNInputValue(exclude)
+			runner.addHosts(ips)
+		case iputil.IsPort(exclude):
+			runner.excludePorts[exclude] = struct{}{}
+		case isValidRegex(exclude):
+			runner.excludeRegexes[exclude] = struct{}{}
+		default:
+			URL := strings.TrimSpace(exclude)
+			if urlx, err := urlutil.Parse(URL); err == nil {
+				runner.excludeHosts[urlx.Host] = struct{}{}
+			}
+		}
+	}
+
 	httpxOptions := httpx.DefaultOptions
 	// Enables automatically tlsgrab if tlsprobe is requested
 	httpxOptions.TLSGrab = options.TLSGrab || options.TLSProbe
@@ -127,8 +159,8 @@ func New(options *Options) (*Runner, error) {
 	httpxOptions.Unsafe = options.Unsafe
 	httpxOptions.UnsafeURI = options.RequestURI
 	httpxOptions.CdnCheck = options.OutputCDN
-	httpxOptions.ExcludeCdn = options.ExcludeCDN
-	httpxOptions.ExcludePrivateHosts = options.ExcludePrivateHosts
+	httpxOptions.ExcludeCdn = runner.excludeCdn
+	httpxOptions.ExcludePrivateHosts = runner.excludePrivateHosts
 	if options.CustomHeaders.Has("User-Agent:") {
 		httpxOptions.RandomAgent = false
 	} else {
@@ -293,8 +325,8 @@ func New(options *Options) (*Runner, error) {
 		scanopts.OutputMethod = true
 	}
 
-	scanopts.ExcludeCDN = options.ExcludeCDN
-	scanopts.ExcludePrivateHosts = options.ExcludePrivateHosts
+	scanopts.ExcludeCDN = runner.excludeCdn
+	scanopts.ExcludePrivateHosts = runner.excludePrivateHosts
 	scanopts.HostMaxErrors = options.HostMaxErrors
 	scanopts.ProbeAllIPS = options.ProbeAllIPS
 	scanopts.Favicon = options.Favicon
@@ -338,6 +370,35 @@ func New(options *Options) (*Runner, error) {
 	runner.errorPageClassifier = errorpageclassifier.New()
 
 	return runner, nil
+}
+
+func expandCIDRInputValue(value string) []string {
+	var ips []string
+	ipsCh, _ := mapcidr.IPAddressesAsStream(value)
+	for ip := range ipsCh {
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+func expandASNInputValue(value string) []string {
+	var ips []string
+	cidrs, _ := asn.GetCIDRsForASNNum(value)
+	for _, cidr := range cidrs {
+		ips = append(ips, expandCIDRInputValue(cidr.String())...)
+	}
+	return ips
+}
+
+func (r *Runner) addHosts(hosts []string) {
+	for _, host := range hosts {
+		r.excludeHosts[host] = struct{}{}
+	}
+}
+
+func isValidRegex(pattern string) bool {
+	_, err := regexp.Compile(pattern)
+	return err == nil
 }
 
 func (r *Runner) prepareInputPaths() {
@@ -1306,15 +1367,10 @@ retry:
 		}
 	}
 
-	if r.skipPrivateHosts(URL.Hostname()) {
-		gologger.Debug().Msgf("Skipping private host %s\n", URL.Host)
-		return Result{URL: target.Host, Input: origInput, Err: errors.New("target has a private ip and will only connect within same local network")}
-	}
-
 	// check if the combination host:port should be skipped if belonging to a cdn
-	if r.skipCDNPort(URL.Host, URL.Port()) {
-		gologger.Debug().Msgf("Skipping cdn target: %s:%s\n", URL.Host, URL.Port())
-		return Result{URL: target.Host, Input: origInput, Err: errors.New("cdn target only allows ports 80 and 443")}
+	skip, reason := r.skip(URL, target, origInput)
+	if skip {
+		return reason
 	}
 
 	URL.Scheme = protocol
@@ -2031,6 +2087,42 @@ retry:
 	return result
 }
 
+func (r *Runner) skip(URL *urlutil.URL, target httpx.Target, origInput string) (bool, Result) {
+	if r.skipPrivateHosts(URL.Hostname()) {
+		gologger.Debug().Msgf("Skipping private host %s\n", URL.Host)
+		return true, Result{URL: target.Host, Input: origInput, Err: errors.New("target has a private ip and will only connect within same local network")}
+	}
+
+	if r.skipCDNPort(URL.Host, URL.Port()) {
+		gologger.Debug().Msgf("Skipping cdn target: %s:%s\n", URL.Host, URL.Port())
+		return true, Result{URL: target.Host, Input: origInput, Err: errors.New("cdn target only allows ports 80 and 443")}
+	}
+
+	if _, ok := r.excludeHosts[URL.Host]; ok {
+		gologger.Debug().Msgf("Skipping excluded host %s\n", URL.Host)
+		return true, Result{URL: target.Host, Input: origInput, Err: errors.New("host is in the exclude list")}
+	}
+
+	if _, ok := r.excludePorts[URL.Port()]; ok {
+		gologger.Debug().Msgf("Skipping excluded port: %s:%s\n", URL.Hostname(), URL.Port())
+		return true, Result{URL: target.Host, Input: origInput, Err: errors.New("port is in the exclude list")}
+	}
+
+	for regex := range r.excludeRegexes {
+		matched, err := regexp.MatchString(regex, URL.String())
+		if err != nil {
+			gologger.Debug().Msgf("Error matching regex: %s\n", err)
+			continue
+		}
+		if matched {
+			gologger.Debug().Msgf("Skipping URL matching exclude regex: %s\n", URL.String())
+			return true, Result{URL: target.Host, Input: origInput, Err: errors.New("url matches an exclude regex")}
+		}
+	}
+
+	return false, Result{}
+}
+
 func calculatePerceptionHash(screenshotBytes []byte) (uint64, error) {
 	reader := bytes.NewReader(screenshotBytes)
 	img, _, err := image.Decode(reader)
@@ -2195,7 +2287,7 @@ func (r Result) CSVRow(scanopts *ScanOptions) string { //nolint
 
 func (r *Runner) skipCDNPort(host string, port string) bool {
 	// if the option is not enabled we don't skip
-	if !r.options.ExcludeCDN {
+	if !r.scanopts.ExcludeCDN {
 		return false
 	}
 	// uses the dealer to pre-resolve the target
@@ -2227,7 +2319,7 @@ func (r *Runner) skipCDNPort(host string, port string) bool {
 
 func (r *Runner) skipPrivateHosts(host string) bool {
 	// if the option is not enabled we don't skip
-	if !r.options.ExcludePrivateHosts {
+	if !r.scanopts.ExcludePrivateHosts {
 		return false
 	}
 	dnsData, err := r.hp.Dialer.GetDNSData(host)


### PR DESCRIPTION
Closes #1427


```console
go run . -exclude 'cdn,private-ips,http://*scanme.sh,443,1.0.0.0/24' -u http://scanme.sh,127.0.0.1,scanme.sh:443,projectdiscovery.io,example.com -v  

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.7 (latest)
[DBG] Skipping private host 127.0.0.1
[DBG] Failed '127.0.0.1': target has a private ip and will only connect within same local network
[DBG] Skipping URL matching exclude regex: http://scanme.sh
[DBG] Failed 'http://scanme.sh': url matches an exclude regex
[DBG] Skipping cdn target: projectdiscovery.io:
[DBG] Failed 'projectdiscovery.io': cdn target only allows ports 80 and 443
https://example.com
[DBG] Skipping excluded port: scanme.sh:443
[DBG] Failed 'scanme.sh:443': port is in the exclude list
```