### PR TITLE
Fix exclude cdn option

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2267,7 +2268,7 @@ func (r *Runner) skipCDNPort(host string, port string) bool {
 		return false
 	}
 
-	if isCdnIP && sliceutil.Contains(r.options.CustomPorts, port) {
+	if isCdnIP && slices.Contains(r.options.CustomPorts, port) {
 		return true
 	}
 	// If the target is part of the CDN ips range - only ports 80 and 443 are allowed

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2267,11 +2267,11 @@ func (r *Runner) skipCDNPort(host string, port string) bool {
 		return false
 	}
 
-	if sliceutil.Contains(r.options.Exclude, "cdn") && isCdnIP {
+	if isCdnIP && sliceutil.Contains(r.options.CustomPorts, port) {
 		return true
 	}
 	// If the target is part of the CDN ips range - only ports 80 and 443 are allowed
-	if isCdnIP && port != "" && port != "80" && port != "443" {
+	if isCdnIP && port != "80" && port != "443" {
 		return true
 	}
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2068,7 +2068,7 @@ retry:
 }
 
 func (r *Runner) skip(URL *urlutil.URL, target httpx.Target, origInput string) (bool, Result) {
-	if r.skipCDNPort(URL.Host, URL.Port()) {
+	if r.skipCDNPort(URL.Hostname(), URL.Port()) {
 		gologger.Debug().Msgf("Skipping cdn target: %s:%s\n", URL.Host, URL.Port())
 		return true, Result{URL: target.Host, Input: origInput, Err: errors.New("cdn target only allows ports 80 and 443")}
 	}
@@ -2267,6 +2267,9 @@ func (r *Runner) skipCDNPort(host string, port string) bool {
 		return false
 	}
 
+	if sliceutil.Contains(r.options.Exclude, "cdn") && isCdnIP {
+		return true
+	}
 	// If the target is part of the CDN ips range - only ports 80 and 443 are allowed
 	if isCdnIP && port != "" && port != "80" && port != "443" {
 		return true


### PR DESCRIPTION
- closes #1417 

```console
✗ go run . -u projectdiscovery.io,scanme.sh -cdn -e cdn

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.3.9 (latest)
https://scanme.sh
```