### PR TITLE
Fix content rel issues

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -288,10 +288,12 @@ get_response:
 
 	// fill metrics
 	resp.StatusCode = httpresp.StatusCode
-	// number of words
-	resp.Words = len(strings.Split(respbodystr, " "))
-	// number of lines
-	resp.Lines = len(strings.Split(respbodystr, "\n"))
+	if respbodystr != "" {
+		// number of words
+		resp.Words = len(strings.Split(respbodystr, " "))
+		// number of lines
+		resp.Lines = len(strings.Split(strings.TrimSpace(respbodystr), "\n"))
+	}
 
 	if !h.Options.Unsafe && h.Options.TLSGrab {
 		if h.Options.ZTLS {

--- a/runner/types.go
+++ b/runner/types.go
@@ -73,7 +73,7 @@ type Result struct {
 	Words              int                    `json:"words" csv:"words"`
 	Lines              int                    `json:"lines" csv:"lines"`
 	StatusCode         int                    `json:"status_code,omitempty" csv:"status_code"`
-	ContentLength      int                    `json:"content_length,omitempty" csv:"content_length"`
+	ContentLength      int                    `json:"content_length" csv:"content_length"`
 	Failed             bool                   `json:"failed" csv:"failed"`
 	VHost              bool                   `json:"vhost,omitempty" csv:"vhost"`
 	WebSocket          bool                   `json:"websocket,omitempty" csv:"websocket"`


### PR DESCRIPTION
Closes #1629

```console
$ export SHOW_DSL_ERRORS=true

$ go run . -u "localhost:8000" -path "/nothing_cl0" -fdc "content_length < 1" -debug

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.6.0 (latest)
[INF] Dumped HTTP request for https://localhost:8000/nothing_cl0

GET /nothing_cl0 HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0
Accept-Charset: utf-8
Accept-Encoding: gzip

[INF] Dumped HTTP request for http://localhost:8000/nothing_cl0

GET /nothing_cl0 HTTP/1.1
Host: localhost:8000
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0
Accept-Charset: utf-8
Accept-Encoding: gzip

[INF] Dumped HTTP response for http://localhost:8000/nothing_cl0

HTTP/1.0 200 OK
Connection: close
Date: Wed, 13 Mar 2024 16:21:24 GMT
Server: BaseHTTP/0.6 Python/3.12.2
Content-Length: 0
```
[This is the example](https://github.com/projectdiscovery/httpx/issues/1629#issuecomment-1994523410) server used for this test.