### PR TITLE
Adding -protocol/-pr option for http1.1

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -150,6 +151,12 @@ func New(options *Options) (*HTTPX, error) {
 			MinVersion:         tls.VersionTLS10,
 		},
 		DisableKeepAlives: true,
+	}
+
+	if httpx.Options.Protocol == "http11" {
+		// disable http2
+		os.Setenv("GODEBUG", "http2client=0")
+		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	}
 
 	if httpx.Options.SniName != "" {

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -45,6 +45,7 @@ type Options struct {
 	SniName                   string
 	TlsImpersonate            bool
 	NetworkPolicy             *networkpolicy.NetworkPolicy
+	Protocol                  Proto
 }
 
 // DefaultOptions contains the default options

--- a/common/httpx/proto.go
+++ b/common/httpx/proto.go
@@ -3,8 +3,8 @@ package httpx
 type Proto string
 
 const (
-	AUTO   Proto = "auto"
-	HTTP11 Proto = "http11"
-	HTTP2  Proto = "http2"
-	HTTP3  Proto = "http3"
+	UNKNOWN Proto = ""
+	HTTP11  Proto = "http11"
+	HTTP2   Proto = "http2"
+	HTTP3   Proto = "http3"
 )

--- a/common/httpx/proto.go
+++ b/common/httpx/proto.go
@@ -1,0 +1,10 @@
+package httpx
+
+type Proto string
+
+const (
+	AUTO   Proto = "auto"
+	HTTP11 Proto = "http11"
+	HTTP2  Proto = "http2"
+	HTTP3  Proto = "http3"
+)

--- a/runner/options.go
+++ b/runner/options.go
@@ -22,11 +22,13 @@ import (
 	"github.com/projectdiscovery/httpx/common/customlist"
 	customport "github.com/projectdiscovery/httpx/common/customports"
 	fileutilz "github.com/projectdiscovery/httpx/common/fileutil"
+	"github.com/projectdiscovery/httpx/common/httpx"
 	"github.com/projectdiscovery/httpx/common/slice"
 	"github.com/projectdiscovery/httpx/common/stringz"
 	"github.com/projectdiscovery/utils/auth/pdcp"
 	"github.com/projectdiscovery/utils/env"
 	fileutil "github.com/projectdiscovery/utils/file"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 	updateutils "github.com/projectdiscovery/utils/update"
 )
 
@@ -297,6 +299,7 @@ type Options struct {
 	ScreenshotTimeout  int
 	// HeadlessOptionalArguments specifies optional arguments to pass to Chrome
 	HeadlessOptionalArguments goflags.StringSlice
+	Protocol                  string
 }
 
 // ParseOptions parses the command line options for application
@@ -417,6 +420,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.chainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 		flagSet.BoolVarP(&options.StoreVisionReconClusters, "store-vision-recon-cluster", "svrc", false, "include visual recon clusters (-ss and -sr only)"),
+		flagSet.StringVarP(&options.Protocol, "protocol", "pr", "auto", "protocol to use (auto, http11)"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",
@@ -666,6 +670,10 @@ func (options *Options) ValidateOptions() error {
 	}
 	if len(options.OutputMatchCdn) > 0 || len(options.OutputFilterCdn) > 0 {
 		options.OutputCDN = "true"
+	}
+
+	if !stringsutil.EqualFoldAny(options.Protocol, string(httpx.AUTO), string(httpx.HTTP11)) {
+		return fmt.Errorf("invalid protocol: %s", options.Protocol)
 	}
 
 	return nil

--- a/runner/options.go
+++ b/runner/options.go
@@ -420,7 +420,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.chainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 		flagSet.BoolVarP(&options.StoreVisionReconClusters, "store-vision-recon-cluster", "svrc", false, "include visual recon clusters (-ss and -sr only)"),
-		flagSet.StringVarP(&options.Protocol, "protocol", "pr", "auto", "protocol to use (auto, http11)"),
+		flagSet.StringVarP(&options.Protocol, "protocol", "pr", "", "protocol to use (unknown, http11)"),
 	)
 
 	flagSet.CreateGroup("configs", "Configurations",
@@ -672,7 +672,7 @@ func (options *Options) ValidateOptions() error {
 		options.OutputCDN = "true"
 	}
 
-	if !stringsutil.EqualFoldAny(options.Protocol, string(httpx.AUTO), string(httpx.HTTP11)) {
+	if !stringsutil.EqualFoldAny(options.Protocol, string(httpx.UNKNOWN), string(httpx.HTTP11)) {
 		return fmt.Errorf("invalid protocol: %s", options.Protocol)
 	}
 


### PR DESCRIPTION
Closes #1633 

```console
$ echo http://127.0.0.1:8000 | go run . -json -pr http11 -x head

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

{"timestamp":"2024-04-15T21:44:37.084762+02:00","port":"8000","url":"http://127.0.0.1:8000","input":"http://127.0.0.1:8000","scheme":"http","content_type":"text/html","method":"HEAD","host":"127.0.0.1","path":"/","time":"7.966811ms","a":["127.0.0.1"],"words":0,"lines":0,"status_code":200,"content_length":444,"failed":false,"knowledgebase":{"PageType":"other","pHash":0}}
```