### PR TITLE
do not trim protocol

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1310,7 +1310,7 @@ func (r *Runner) process(t string, wg *syncutil.AdaptiveWaitGroup, hp *httpx.HTT
 		protocols = []string{httpx.HTTPS, httpx.HTTP}
 	}
 
-	for target := range r.targets(hp, stringz.TrimProtocol(t, scanopts.NoFallback || scanopts.NoFallbackScheme)) {
+	for target := range r.targets(hp, t) {
 		// if no custom ports specified then test the default ones
 		if len(customport.Ports) == 0 {
 			for _, method := range scanopts.Methods {


### PR DESCRIPTION
Closes #1770

```console
$ go run . -u http://127.0.0.1/1  -nf -v

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.6.5 (latest)
[DBG] Failed 'http://127.0.0.1/1': Get "http://127.0.0.1/1": errKind=network-permanent-error [address=127.0.0.1:80] port closed or filtered; connection refused
[DBG] Failed 'https://127.0.0.1/1': Get "https://127.0.0.1/1": errKind=network-permanent-error [address=127.0.0.1:443] port closed or filtered; connection refused

$ go run . -u http://127.0.0.1/1  -nfs -v

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.6.5 (latest)
[DBG] Failed 'http://127.0.0.1/1': Get "http://127.0.0.1/1": errKind=network-permanent-error [address=127.0.0.1:80] port closed or filtered; connection refused

```