### PR TITLE
add md5 hash support for favicon

### DIFF
--- a/common/stringz/stringz.go
+++ b/common/stringz/stringz.go
@@ -2,7 +2,9 @@ package stringz
 
 import (
 	"bytes"
+	"crypto/md5"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"net/http"
 	"net/url"
@@ -121,12 +123,19 @@ func murmurhash(data []byte) int32 {
 	return int32(hasher.Sum32())
 }
 
-func FaviconHash(data []byte) (int32, error) {
+// md5Hash returns the md5 hash of the data
+func md5Hash(data []byte) string {
+	hasher := md5.New()
+	hasher.Write(data)
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func FaviconHash(data []byte) (int32, string, error) {
 	if isContentTypeImage(data) {
-		return murmurhash(data), nil
+		return murmurhash(data), md5Hash(data), nil
 	}
 
-	return 0, errors.New("content type is not image")
+	return 0, "", errors.New("content type is not image")
 }
 
 func InsertInto(s string, interval int, sep rune) string {

--- a/runner/types.go
+++ b/runner/types.go
@@ -59,6 +59,7 @@ type Result struct {
 	Host               string                 `json:"host,omitempty" csv:"host"`
 	Path               string                 `json:"path,omitempty" csv:"path"`
 	FavIconMMH3        string                 `json:"favicon,omitempty" csv:"favicon"`
+	FavIconMD5         string                 `json:"favicon_md5,omitempty" csv:"favicon"`
 	FaviconPath        string                 `json:"favicon_path,omitempty" csv:"favicon_path"`
 	FaviconURL         string                 `json:"favicon_url,omitempty" csv:"favicon_url"`
 	FinalURL           string                 `json:"final_url,omitempty" csv:"final_url"`


### PR DESCRIPTION
Closes #1791

```console
$ go run . -u hackerone.com -silent -favicon -j | jq .favicon_md5
"e2ed1a24ed8db1f5b522359b1661e54e"
```