### PR TITLE
Favicon support md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ PROBES:
    -cl, -content-length   display response content-length
    -ct, -content-type     display response content-type
    -location              display response redirect location
-   -favicon               display mmh3 hash for '/favicon.ico' file
+   -favicon               display hash for '/favicon.ico' file (supported: md5,mmh3)
    -hash string           display response body hash (supported: md5,mmh3,simhash,sha1,sha256,sha512)
    -jarm                  display jarm fingerprint hash
    -rt, -response-time    display response time

--- a/common/stringz/stringz.go
+++ b/common/stringz/stringz.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"github.com/projectdiscovery/httpx/common/hashes"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
 	"github.com/spaolacci/murmur3"
@@ -121,12 +123,15 @@ func murmurhash(data []byte) int32 {
 	return int32(hasher.Sum32())
 }
 
-func FaviconHash(data []byte) (int32, error) {
+func FaviconHash(data []byte, algo string) (string, error) {
 	if isContentTypeImage(data) {
-		return murmurhash(data), nil
+		if algo == "md5" {
+			return hashes.Md5(data), nil
+		}
+		return fmt.Sprintf("%d", murmurhash(data)), nil
 	}
 
-	return 0, errors.New("content type is not image")
+	return "", errors.New("content type is not image")
 }
 
 func InsertInto(s string, interval int, sep rune) string {

--- a/runner/options.go
+++ b/runner/options.go
@@ -90,7 +90,7 @@ type ScanOptions struct {
 	ExcludeCDN                bool
 	HostMaxErrors             int
 	ProbeAllIPS               bool
-	Favicon                   bool
+	Favicon                   string
 	LeaveDefaultPorts         bool
 	OutputLinesCount          bool
 	OutputWordsCount          bool
@@ -264,7 +264,7 @@ type Options struct {
 	SkipDedupe                bool
 	ProbeAllIPS               bool
 	Resolvers                 goflags.StringSlice
-	Favicon                   bool
+	Favicon                   string
 	OutputFilterFavicon       goflags.StringSlice
 	OutputMatchFavicon        goflags.StringSlice
 	LeaveDefaultPorts         bool
@@ -334,7 +334,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.ContentLength, "content-length", "cl", false, "display response content-length"),
 		flagSet.BoolVarP(&options.OutputContentType, "content-type", "ct", false, "display response content-type"),
 		flagSet.BoolVar(&options.Location, "location", false, "display response redirect location"),
-		flagSet.BoolVar(&options.Favicon, "favicon", false, "display mmh3 hash for '/favicon.ico' file"),
+		flagSet.StringVar(&options.Favicon, "favicon", "", "display hash for '/favicon.ico' file (supported: md5,mmh3)"),
 		flagSet.StringVar(&options.Hashes, "hash", "", "display response body hash (supported: md5,mmh3,simhash,sha1,sha256,sha512)"),
 		flagSet.BoolVar(&options.Jarm, "jarm", false, "display jarm fingerprint hash"),
 		flagSet.BoolVarP(&options.OutputResponseTime, "response-time", "rt", false, "display response time"),
@@ -662,6 +662,12 @@ func (options *Options) ValidateOptions() error {
 			}
 		} else {
 			resolvers = append(resolvers, resolver)
+		}
+	}
+
+	if options.Favicon != "" {
+		if !sliceutil.Contains([]string{"md5", "mmh3"}, strings.ToLower(options.Favicon)) {
+			return errors.Wrapf(err, "Invalid value for favicon, supported values: md5, mmh3")
 		}
 	}
 

--- a/runner/types.go
+++ b/runner/types.go
@@ -58,7 +58,7 @@ type Result struct {
 	Method             string                 `json:"method,omitempty" csv:"method"`
 	Host               string                 `json:"host,omitempty" csv:"host"`
 	Path               string                 `json:"path,omitempty" csv:"path"`
-	FavIconMMH3        string                 `json:"favicon,omitempty" csv:"favicon"`
+	FavIconHash        string                 `json:"favicon,omitempty" csv:"favicon"`
 	FaviconPath        string                 `json:"favicon_path,omitempty" csv:"favicon_path"`
 	FaviconURL         string                 `json:"favicon_url,omitempty" csv:"favicon_url"`
 	FinalURL           string                 `json:"final_url,omitempty" csv:"final_url"`

--- a/static/html-summary.html
+++ b/static/html-summary.html
@@ -83,7 +83,7 @@
                         {{if $Favicon}}
                         <li>
                             <strong>Favicon:</strong>
-                            <a style="text-decoration: none; color: blue">{{.FavIconMMH3}}</a>
+                            <a style="text-decoration: none; color: blue">{{.FavIconHash}}</a>
                         </li>
                         {{end}}
                         {{if $OutputResponseTime}}


### PR DESCRIPTION
```
./httpx -u hackerone.com -silent -favicon md5 -j  | jq .favicon
"e2ed1a24ed8db1f5b522359b1661e54e"
```

closes https://github.com/projectdiscovery/httpx/issues/1791

I started working on this before looking at open issues and pull requests as I needed MD5 for rapid7's recog database . Looks like someone beat me to it. Feel free to close. The only major difference between the PR's is that mine asks for a Hash algorithm to be specified on the command line. 

https://github.com/projectdiscovery/httpx/pull/1799

