### PR TITLE
rename Jarm to JarmHash to avoid confusion

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2204,7 +2204,7 @@ retry:
 		FaviconURL:       faviconURL,
 		Hashes:           hashesMap,
 		Extracts:         extractResult,
-		Jarm:             jarmhash,
+		JarmHash:         jarmhash,
 		Lines:            resp.Lines,
 		Words:            resp.Words,
 		ASN:              asnResponse,

--- a/runner/types.go
+++ b/runner/types.go
@@ -67,7 +67,7 @@ type Result struct {
 	RawHeaders         string                 `json:"raw_header,omitempty" csv:"raw_header"`
 	Request            string                 `json:"request,omitempty" csv:"request"`
 	ResponseTime       string                 `json:"time,omitempty" csv:"time"`
-	Jarm               string                 `json:"jarm,omitempty" csv:"jarm"`
+	JarmHash           string                 `json:"jarm_hash,omitempty" csv:"jarm_hash"`
 	ChainStatusCodes   []int                  `json:"chain_status_codes,omitempty" csv:"chain_status_codes"`
 	A                  []string               `json:"a,omitempty" csv:"a"`
 	AAAA               []string               `json:"aaaa,omitempty" csv:"aaaa"`


### PR DESCRIPTION
Closes #1805

```console
$ go run . -u https://google.com -jarm -mdc 'jarm_hash == "27d40d40d29d40d1dc42d43d00041d4689ee210389f4f6b4b5b1b93f92252d"'  

    __    __  __       _  __
   / /_  / /_/ /_____ | |/ /
  / __ \/ __/ __/ __ \|   /
 / / / / /_/ /_/ /_/ /   |
/_/ /_/\__/\__/ .___/_/|_|
             /_/

                projectdiscovery.io

[INF] Current httpx version v1.6.6 (latest)
https://google.com [27d40d40d29d40d1dc42d43d00041d4689ee210389f4f6b4b5b1b93f92252d]
```