### PR TITLE
add disable stdout option

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -309,6 +309,7 @@ type Options struct {
 	HeadlessOptionalArguments goflags.StringSlice
 	Protocol                  string
 	OutputFilterErrorPagePath string
+	DisableStdout             bool
 	// AssetUpload
 	AssetUpload bool
 	// AssetName

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1098,7 +1098,7 @@ func (r *Runner) RunEnumeration() {
 				}
 			}
 
-			if !jsonOrCsv || jsonAndCsv || r.options.OutputAll {
+			if !r.options.DisableStdout && (!jsonOrCsv || jsonAndCsv || r.options.OutputAll) {
 				gologger.Silent().Msgf("%s\n", resp.str)
 			}
 


### PR DESCRIPTION
Closes #1692

```go
package main

import (
	"fmt"
	"log"

	"github.com/projectdiscovery/goflags"
	"github.com/projectdiscovery/httpx/runner"
)

func main() {
	results := map[string]struct{}{}

	options := runner.Options{
		Methods:         "GET",
		Timeout:         5,
		Threads:         80,
		Silent:          true,
		RandomAgent:     true,
		Retries:         2,
		DisableStdout:   true,
		InputTargetHost: goflags.StringSlice{"scanme.sh", "projectdiscovery.io", "localhost", "x"},
		OnResult: func(r runner.Result) {
			if r.Err != nil {
				return
			}
			results[r.URL] = struct{}{}
		},
	}

	if err := options.ValidateOptions(); err != nil {
		log.Fatal(err)
	}

	httpxRunner, err := runner.New(&options)
	if err != nil {
		log.Fatal(err)
	}
	defer httpxRunner.Close()

	httpxRunner.RunEnumeration()
	fmt.Println("Results:", results)
}
```

```console
$ go run .
Results: map[https://projectdiscovery.io:{} https://scanme.sh:{}]
```