### PR TITLE
feat(runner): use `gocsv` to marshal `Result`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/felixge/fgprof v0.9.5 // indirect
 	github.com/gaissmai/bart v0.17.10 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/certificate-transparency-go v1.1.4 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1
+	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/weppos/publicsuffix-go v0.40.2
 )
 
@@ -85,7 +86,6 @@ require (
 	github.com/felixge/fgprof v0.9.5 // indirect
 	github.com/gaissmai/bart v0.17.10 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/certificate-transparency-go v1.1.4 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlnd
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 h1:FWNFq4fM1wPfcK40yHE5UO3RUdSNPaBC+j3PokzA6OQ=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2500,7 +2500,7 @@ func (r Result) CSVRow(scanopts *ScanOptions) string { //nolint
 						}
 					}
 				}
-				writer.Write(record)
+				_ = writer.Write(record) //nolint
 			}
 			writer.Flush()
 			res = buf.String()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/corona10/goimagehash"
+	"github.com/gocarina/gocsv"
 	"github.com/mfonda/simhash"
 	asnmap "github.com/projectdiscovery/asnmap/libs"
 	"github.com/projectdiscovery/fastdialer/fastdialer"
@@ -2466,57 +2466,51 @@ func (r Result) JSON(scanopts *ScanOptions) string { //nolint
 
 // CSVHeader the CSV headers
 func (r Result) CSVHeader() string { //nolint
-	buffer := bytes.Buffer{}
-	writer := csv.NewWriter(&buffer)
+	var header string
 
-	var headers []string
-	ty := reflect.TypeOf(r)
-	for i := 0; i < ty.NumField(); i++ {
-		tag := ty.Field(i).Tag.Get("csv")
-		if ignored := (tag == "" || tag == "-"); ignored {
-			continue
-		}
-
-		headers = append(headers, tag)
+	if h, err := gocsv.MarshalString([]Result{}); err == nil {
+		header = h
 	}
-	_ = writer.Write(headers)
-	writer.Flush()
+	header = strings.TrimSpace(header)
 
-	return strings.TrimSpace(buffer.String())
+	return header
 }
 
 // CSVRow the CSV Row
 func (r Result) CSVRow(scanopts *ScanOptions) string { //nolint
+	var res string
+
 	if scanopts != nil && len(r.ResponseBody) > scanopts.MaxResponseBodySizeToSave {
 		r.ResponseBody = r.ResponseBody[:scanopts.MaxResponseBodySizeToSave]
 	}
 
-	buffer := bytes.Buffer{}
-	writer := csv.NewWriter(&buffer)
-
-	var cells []string
-	elem := reflect.ValueOf(r)
-	for i := 0; i < elem.NumField(); i++ {
-		value := elem.Field(i)
-		tag := elem.Type().Field(i).Tag.Get(`csv`)
-		if ignored := (tag == "" || tag == "-"); ignored {
-			continue
+	if row, err := gocsv.MarshalStringWithoutHeaders([]Result{r}); err == nil {
+		reader := csv.NewReader(strings.NewReader(row))
+		records, err := reader.ReadAll()
+		if err == nil && len(records) > 0 {
+			buf := &bytes.Buffer{}
+			writer := csv.NewWriter(buf)
+			for _, record := range records {
+				for i, field := range record {
+					if len(field) > 0 {
+						firstChar := field[0]
+						// NOTE(dwisiswant0): Sanitize (prevent CSV injection).
+						if firstChar == '=' || firstChar == '+' || firstChar == '-' || firstChar == '@' {
+							record[i] = "'" + field
+						}
+					}
+				}
+				writer.Write(record)
+			}
+			writer.Flush()
+			res = buf.String()
+		} else {
+			res = row
 		}
-
-		str := fmt.Sprintf("%v", value.Interface())
-
-		// defense against csv injection
-		startWithRiskyChar, _ := regexp.Compile(`^([=+\-@])`)
-		if startWithRiskyChar.Match([]byte(str)) {
-			str = "'" + str
-		}
-
-		cells = append(cells, str)
+		res = strings.TrimSpace(res)
 	}
-	_ = writer.Write(cells)
-	writer.Flush()
 
-	return strings.TrimSpace(buffer.String()) // remove "\n" in the end
+	return res
 }
 
 func (r *Runner) skipCDNPort(host string, port string) bool {

--- a/runner/types.go
+++ b/runner/types.go
@@ -34,11 +34,11 @@ func (o AsnResponse) String() string {
 // Result of a scan
 type Result struct {
 	Timestamp          time.Time                     `json:"timestamp,omitempty" csv:"timestamp" mapstructure:"timestamp"`
-	ASN                *AsnResponse                  `json:"asn,omitempty" csv:"asn" mapstructure:"asn"`
+	ASN                *AsnResponse                  `json:"asn,omitempty" csv:"-" mapstructure:"asn"`
 	Err                error                         `json:"-" csv:"-" mapstructure:"-"`
-	CSPData            *httpx.CSPData                `json:"csp,omitempty" csv:"csp" mapstructure:"csp"`
-	TLSData            *clients.Response             `json:"tls,omitempty" csv:"tls" mapstructure:"tls"`
-	Hashes             map[string]interface{}        `json:"hash,omitempty" csv:"hash" mapstructure:"hash"`
+	CSPData            *httpx.CSPData                `json:"csp,omitempty" csv:"-" mapstructure:"csp"`
+	TLSData            *clients.Response             `json:"tls,omitempty" csv:"-" mapstructure:"tls"`
+	Hashes             map[string]interface{}        `json:"hash,omitempty" csv:"-" mapstructure:"hash"`
 	ExtractRegex       []string                      `json:"extract_regex,omitempty" csv:"extract_regex" mapstructure:"extract_regex"`
 	CDNName            string                        `json:"cdn_name,omitempty" csv:"cdn_name" mapstructure:"cdn_name"`
 	CDNType            string                        `json:"cdn_type,omitempty" csv:"cdn_type" mapstructure:"cdn_type"`
@@ -49,7 +49,7 @@ type Result struct {
 	Input              string                        `json:"input,omitempty" csv:"input" mapstructure:"input"`
 	Location           string                        `json:"location,omitempty" csv:"location" mapstructure:"location"`
 	Title              string                        `json:"title,omitempty" csv:"title" mapstructure:"title"`
-	str                string                        `mapstructure:"-"`
+	str                string                        `json:"-" csv:"-" mapstructure:"-"`
 	Scheme             string                        `json:"scheme,omitempty" csv:"scheme" mapstructure:"scheme"`
 	Error              string                        `json:"error,omitempty" csv:"error" mapstructure:"error"`
 	WebServer          string                        `json:"webserver,omitempty" csv:"webserver" mapstructure:"webserver"`
@@ -74,8 +74,8 @@ type Result struct {
 	AAAA               []string                      `json:"aaaa,omitempty" csv:"aaaa" mapstructure:"aaaa"`
 	CNAMEs             []string                      `json:"cname,omitempty" csv:"cname" mapstructure:"cname"`
 	Technologies       []string                      `json:"tech,omitempty" csv:"tech" mapstructure:"tech"`
-	Extracts           map[string][]string           `json:"extracts,omitempty" csv:"extracts" mapstructure:"extracts"`
-	Chain              []httpx.ChainItem             `json:"chain,omitempty" csv:"chain" mapstructure:"chain"`
+	Extracts           map[string][]string           `json:"extracts,omitempty" csv:"-" mapstructure:"extracts"`
+	Chain              []httpx.ChainItem             `json:"chain,omitempty" csv:"-" mapstructure:"chain"`
 	Words              int                           `json:"words" csv:"words" mapstructure:"words"`
 	Lines              int                           `json:"lines" csv:"lines" mapstructure:"lines"`
 	StatusCode         int                           `json:"status_code" csv:"status_code" mapstructure:"status_code"`
@@ -91,15 +91,15 @@ type Result struct {
 	StoredResponsePath string                        `json:"stored_response_path,omitempty" csv:"stored_response_path" mapstructure:"stored_response_path"`
 	ScreenshotPath     string                        `json:"screenshot_path,omitempty" csv:"screenshot_path" mapstructure:"screenshot_path"`
 	ScreenshotPathRel  string                        `json:"screenshot_path_rel,omitempty" csv:"screenshot_path_rel" mapstructure:"screenshot_path_rel"`
-	KnowledgeBase      map[string]interface{}        `json:"knowledgebase,omitempty" csv:"knowledgebase" mapstructure:"knowledgebase"`
+	KnowledgeBase      map[string]interface{}        `json:"knowledgebase,omitempty" csv:"-" mapstructure:"knowledgebase"`
 	Resolvers          []string                      `json:"resolvers,omitempty" csv:"resolvers" mapstructure:"resolvers"`
-	Fqdns              []string                      `json:"body_fqdn,omitempty" mapstructure:"body_fqdn"`
-	Domains            []string                      `json:"body_domains,omitempty" mapstructure:"body_domains"`
+	Fqdns              []string                      `json:"body_fqdn,omitempty" csv:"body_fqdn" mapstructure:"body_fqdn"`
+	Domains            []string                      `json:"body_domains,omitempty" csv:"body_domains" mapstructure:"body_domains"`
 	TechnologyDetails  map[string]wappalyzer.AppInfo `json:"-" csv:"-" mapstructure:"-"`
 	RequestRaw         []byte                        `json:"-" csv:"-" mapstructure:"-"`
 	Response           *httpx.Response               `json:"-" csv:"-" mapstructure:"-"`
 	FaviconData        []byte                        `json:"-" csv:"-" mapstructure:"-"`
-	Trace              *retryablehttp.TraceInfo      `json:"trace,omitempty" csv:"trace"  mapstructure:"trace"`
+	Trace              *retryablehttp.TraceInfo      `json:"trace,omitempty" csv:"-"  mapstructure:"trace"`
 }
 
 type Trace struct {


### PR DESCRIPTION
Fix #2114 

Proof:

```console
$ go run cmd/httpx/httpx.go -u cloud.projectdiscovery.io -csv -silent
timestamp,extract_regex,cdn_name,cdn_type,sni,port,url,input,location,title,scheme,error,webserver,body_preview,content_type,method,host,path,favicon,favicon_md5,favicon_path,favicon_url,final_url,time,jarm_hash,chain_status_codes,a,aaaa,cname,tech,words,lines,status_code,content_length,failed,vhost,websocket,cdn,http2,pipeline,headless_body,screenshot_bytes,stored_response_path,screenshot_path,screenshot_path_rel,resolvers,body_fqdn,body_domains
2025-03-04T06:13:34.688147355+07:00,null,,,,443,https://cloud.projectdiscovery.io,cloud.projectdiscovery.io,,ProjectDiscovery,https,,Vercel,,text/html,GET,66.33.60.66,/,,,,,,166.750912ms,,null,"[""66.33.60.194"",""66.33.60.66""]",null,"[""cname.vercel-dns.com""]","[""Better Stack"",""HSTS"",""Vercel""]",326,1,200,23311,false,false,false,false,false,false,,null,,,,"[""1.1.1.1:53"",""1.0.0.1:53""]",null,null
```