### PR TITLE
feat(headless): add options to specific if screenshot with full page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cmd/functional-test/*.cfg
 /httpx
 /dist
 /resume.cfg
+vendor/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ HEADLESS:
    -system-chrome                   enable using local installed chrome for screenshot
    -ho, -headless-options string[]  start headless chrome with additional options
    -esb, -exclude-screenshot-bytes  enable excluding screenshot bytes from json output
+   -no-screenshot-full-page         disable saving full page screenshot
    -ehb, -exclude-headless-body     enable excluding headless header from json output
    -sfp, -screenshot-full-page      enable saving full page screenshot
    -st, -screenshot-timeout value   set timeout for screenshot in seconds (default 10s)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ HEADLESS:
    -esb, -exclude-screenshot-bytes  enable excluding screenshot bytes from json output
    -no-screenshot-full-page         disable saving full page screenshot
    -ehb, -exclude-headless-body     enable excluding headless header from json output
-   -sfp, -screenshot-full-page      enable saving full page screenshot
    -st, -screenshot-timeout value   set timeout for screenshot in seconds (default 10s)
    -sid, -screenshot-idle value     set idle time before taking screenshot in seconds (default 1s)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ HEADLESS:
    -ho, -headless-options string[]  start headless chrome with additional options
    -esb, -exclude-screenshot-bytes  enable excluding screenshot bytes from json output
    -ehb, -exclude-headless-body     enable excluding headless header from json output
+   -sfp, -screenshot-full-page      enable saving full page screenshot
    -st, -screenshot-timeout value   set timeout for screenshot in seconds (default 10s)
    -sid, -screenshot-idle value     set idle time before taking screenshot in seconds (default 1s)
 

--- a/runner/headless.go
+++ b/runner/headless.go
@@ -99,7 +99,7 @@ func NewBrowser(proxy string, useLocal bool, optionalArgs map[string]string) (*B
 	return engine, nil
 }
 
-func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration, idle time.Duration, headers []string) ([]byte, string, error) {
+func (b *Browser) ScreenshotWithBody(url string, fullPage bool, timeout time.Duration, idle time.Duration, headers []string) ([]byte, string, error) {
 	page, err := b.engine.Page(proto.TargetCreateTarget{})
 	if err != nil {
 		return nil, "", err
@@ -128,7 +128,7 @@ func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration, idle tim
 	}
 	_ = page.WaitIdle(idle)
 
-	screenshot, err := page.Screenshot(true, &proto.PageCaptureScreenshot{})
+	screenshot, err := page.Screenshot(fullPage, &proto.PageCaptureScreenshot{})
 	if err != nil {
 		return nil, "", err
 	}

--- a/runner/headless.go
+++ b/runner/headless.go
@@ -99,7 +99,7 @@ func NewBrowser(proxy string, useLocal bool, optionalArgs map[string]string) (*B
 	return engine, nil
 }
 
-func (b *Browser) ScreenshotWithBody(url string, fullPage bool, timeout time.Duration, idle time.Duration, headers []string) ([]byte, string, error) {
+func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration, idle time.Duration, headers []string, fullPage bool) ([]byte, string, error) {
 	page, err := b.engine.Page(proto.TargetCreateTarget{})
 	if err != nil {
 		return nil, "", err

--- a/runner/options.go
+++ b/runner/options.go
@@ -104,6 +104,7 @@ type ScanOptions struct {
 	DisableStdin              bool
 	NoScreenshotBytes         bool
 	NoHeadlessBody            bool
+	ScreenshotFullPage        bool
 	ScreenshotTimeout         time.Duration
 	ScreenshotIdle            time.Duration
 }
@@ -158,6 +159,7 @@ func (s *ScanOptions) Clone() *ScanOptions {
 		UseInstalledChrome:        s.UseInstalledChrome,
 		NoScreenshotBytes:         s.NoScreenshotBytes,
 		NoHeadlessBody:            s.NoHeadlessBody,
+		ScreenshotFullPage:        s.ScreenshotFullPage,
 		ScreenshotTimeout:         s.ScreenshotTimeout,
 		ScreenshotIdle:            s.ScreenshotIdle,
 	}
@@ -315,6 +317,7 @@ type Options struct {
 	HttpApiEndpoint    string
 	NoScreenshotBytes  bool
 	NoHeadlessBody     bool
+	ScreenshotFullPage bool
 	ScreenshotTimeout  time.Duration
 	ScreenshotIdle     time.Duration
 	// HeadlessOptionalArguments specifies optional arguments to pass to Chrome
@@ -388,6 +391,7 @@ func ParseOptions() *Options {
 		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-options", "ho", nil, "start headless chrome with additional options", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.BoolVarP(&options.NoScreenshotBytes, "exclude-screenshot-bytes", "esb", false, "enable excluding screenshot bytes from json output"),
 		flagSet.BoolVarP(&options.NoHeadlessBody, "exclude-headless-body", "ehb", false, "enable excluding headless header from json output"),
+		flagSet.BoolVarP(&options.ScreenshotFullPage, "screenshot-full-page", "sfp", true, "enable saving full page screenshot"),
 		flagSet.DurationVarP(&options.ScreenshotTimeout, "screenshot-timeout", "st", 10*time.Second, "set timeout for screenshot in seconds"),
 		flagSet.DurationVarP(&options.ScreenshotIdle, "screenshot-idle", "sid", 1*time.Second, "set idle time before taking screenshot in seconds"),
 	)

--- a/runner/options.go
+++ b/runner/options.go
@@ -104,9 +104,13 @@ type ScanOptions struct {
 	DisableStdin              bool
 	NoScreenshotBytes         bool
 	NoHeadlessBody            bool
-	ScreenshotFullPage        bool
+	NoScreenshotFullPage      bool
 	ScreenshotTimeout         time.Duration
 	ScreenshotIdle            time.Duration
+}
+
+func (s *ScanOptions) IsScreenshotFullPage() bool {
+	return !s.NoScreenshotFullPage
 }
 
 func (s *ScanOptions) Clone() *ScanOptions {
@@ -159,7 +163,7 @@ func (s *ScanOptions) Clone() *ScanOptions {
 		UseInstalledChrome:        s.UseInstalledChrome,
 		NoScreenshotBytes:         s.NoScreenshotBytes,
 		NoHeadlessBody:            s.NoHeadlessBody,
-		ScreenshotFullPage:        s.ScreenshotFullPage,
+		NoScreenshotFullPage:      s.NoScreenshotFullPage,
 		ScreenshotTimeout:         s.ScreenshotTimeout,
 		ScreenshotIdle:            s.ScreenshotIdle,
 	}
@@ -307,19 +311,19 @@ type Options struct {
 	OutputMatchCondition      string
 	StripFilter               string
 	//The OnResult callback function is invoked for each result. It is important to check for errors in the result before using Result.Err.
-	OnResult           OnResultCallback
-	DisableUpdateCheck bool
-	NoDecode           bool
-	Screenshot         bool
-	UseInstalledChrome bool
-	TlsImpersonate     bool
-	DisableStdin       bool
-	HttpApiEndpoint    string
-	NoScreenshotBytes  bool
-	NoHeadlessBody     bool
-	ScreenshotFullPage bool
-	ScreenshotTimeout  time.Duration
-	ScreenshotIdle     time.Duration
+	OnResult             OnResultCallback
+	DisableUpdateCheck   bool
+	NoDecode             bool
+	Screenshot           bool
+	UseInstalledChrome   bool
+	TlsImpersonate       bool
+	DisableStdin         bool
+	HttpApiEndpoint      string
+	NoScreenshotBytes    bool
+	NoHeadlessBody       bool
+	NoScreenshotFullPage bool
+	ScreenshotTimeout    time.Duration
+	ScreenshotIdle       time.Duration
 	// HeadlessOptionalArguments specifies optional arguments to pass to Chrome
 	HeadlessOptionalArguments goflags.StringSlice
 	Protocol                  string
@@ -391,7 +395,7 @@ func ParseOptions() *Options {
 		flagSet.StringSliceVarP(&options.HeadlessOptionalArguments, "headless-options", "ho", nil, "start headless chrome with additional options", goflags.FileCommaSeparatedStringSliceOptions),
 		flagSet.BoolVarP(&options.NoScreenshotBytes, "exclude-screenshot-bytes", "esb", false, "enable excluding screenshot bytes from json output"),
 		flagSet.BoolVarP(&options.NoHeadlessBody, "exclude-headless-body", "ehb", false, "enable excluding headless header from json output"),
-		flagSet.BoolVarP(&options.ScreenshotFullPage, "screenshot-full-page", "sfp", true, "enable saving full page screenshot"),
+		flagSet.BoolVar(&options.NoScreenshotFullPage, "no-screenshot-full-page", false, "disable saving full page screenshot"),
 		flagSet.DurationVarP(&options.ScreenshotTimeout, "screenshot-timeout", "st", 10*time.Second, "set timeout for screenshot in seconds"),
 		flagSet.DurationVarP(&options.ScreenshotIdle, "screenshot-idle", "sid", 1*time.Second, "set idle time before taking screenshot in seconds"),
 	)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -296,6 +296,7 @@ func New(options *Options) (*Runner, error) {
 	scanopts.Screenshot = options.Screenshot
 	scanopts.NoScreenshotBytes = options.NoScreenshotBytes
 	scanopts.NoHeadlessBody = options.NoHeadlessBody
+	scanopts.ScreenshotFullPage = options.ScreenshotFullPage
 	scanopts.UseInstalledChrome = options.UseInstalledChrome
 	scanopts.ScreenshotTimeout = options.ScreenshotTimeout
 	scanopts.ScreenshotIdle = options.ScreenshotIdle
@@ -2187,7 +2188,7 @@ retry:
 	var pHash uint64
 	if scanopts.Screenshot {
 		var err error
-		screenshotBytes, headlessBody, err = r.browser.ScreenshotWithBody(fullURL, scanopts.ScreenshotTimeout, scanopts.ScreenshotIdle, r.options.CustomHeaders)
+		screenshotBytes, headlessBody, err = r.browser.ScreenshotWithBody(fullURL, scanopts.ScreenshotFullPage, scanopts.ScreenshotTimeout, scanopts.ScreenshotIdle, r.options.CustomHeaders)
 		if err != nil {
 			gologger.Warning().Msgf("Could not take screenshot '%s': %s", fullURL, err)
 		} else {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -296,7 +296,7 @@ func New(options *Options) (*Runner, error) {
 	scanopts.Screenshot = options.Screenshot
 	scanopts.NoScreenshotBytes = options.NoScreenshotBytes
 	scanopts.NoHeadlessBody = options.NoHeadlessBody
-	scanopts.ScreenshotFullPage = options.ScreenshotFullPage
+	scanopts.NoScreenshotFullPage = options.NoScreenshotFullPage
 	scanopts.UseInstalledChrome = options.UseInstalledChrome
 	scanopts.ScreenshotTimeout = options.ScreenshotTimeout
 	scanopts.ScreenshotIdle = options.ScreenshotIdle
@@ -2188,7 +2188,7 @@ retry:
 	var pHash uint64
 	if scanopts.Screenshot {
 		var err error
-		screenshotBytes, headlessBody, err = r.browser.ScreenshotWithBody(fullURL, scanopts.ScreenshotFullPage, scanopts.ScreenshotTimeout, scanopts.ScreenshotIdle, r.options.CustomHeaders)
+		screenshotBytes, headlessBody, err = r.browser.ScreenshotWithBody(fullURL, scanopts.ScreenshotTimeout, scanopts.ScreenshotIdle, r.options.CustomHeaders, scanopts.IsScreenshotFullPage())
 		if err != nil {
 			gologger.Warning().Msgf("Could not take screenshot '%s': %s", fullURL, err)
 		} else {


### PR DESCRIPTION
When screenshot some long page, like phpinfo, it may takes so many resources, but what we need is only a screenshot to prove the result.

So add a new options named `--screenshot-full-page`, with default value as `true` to keep it works as before, to control the rod wheather screenshot it with full page.