### PR TITLE
fix: resolve Traditional Chinese page garbled text issue

### DIFF
--- a/common/httpx/encodings.go
+++ b/common/httpx/encodings.go
@@ -80,6 +80,8 @@ func DecodeData(data []byte, headers http.Header) ([]byte, error) {
 		switch {
 		case stringsutil.ContainsAny(mcontentType, "gb2312", "gbk"):
 			return Decodegbk(data)
+		case stringsutil.ContainsAny(mcontentType, "big5", "Big5"):
+			return Decodebig5(data)
 		}
 	}
 


### PR DESCRIPTION
In both the main and dev branches, certain Traditional Chinese content is rendered as garbled text due to incorrect or missing character encoding handling.

Root Cause (Suspected)

Some servers return the following response header:
```
Content-Type: text/html; charset=Big5
```
Although most web content today uses:
```
Content-Type: text/html; charset=utf-8
```

Fix Summary
This patch improves compatibility by detecting and correctly handling Big5-encoded responses when applicable. It ensures that Traditional Chinese pages render correctly in edge cases where charset=Big5 is explicitly used.
Example (Before vs. After)
```
../httpx/httpx -silent -u http://freeip.cf/  -title
https://freeip.cf/ [vܩiĤ@Ӯa]


./httpx -silent -u http://freeip.cf/  -title
https://freeip.cf/ [史萊姆的第一個家]

```