### PR TITLE
Dismiss alert lead to take screenshot

### DIFF
--- a/runner/headless.go
+++ b/runner/headless.go
@@ -104,14 +104,14 @@ func (b *Browser) ScreenshotWithBody(url string, timeout time.Duration, idle tim
 	if err != nil {
 		return nil, "", err
 	}
-	wait, handle := page.HandleDialog()
-	go func() {
-		wait()
-		handle(&proto.PageHandleJavaScriptDialog{
+
+	go page.EachEvent(func(e *proto.PageJavascriptDialogOpening) {
+		_ = proto.PageHandleJavaScriptDialog{
 			Accept:     true,
 			PromptText: "",
-		})
-	}()
+		}.Call(page)
+	})()
+
 	for _, header := range headers {
 		headerParts := strings.SplitN(header, ":", 2)
 		if len(headerParts) != 2 {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -713,7 +713,6 @@ func makePrintCallback() func(stats clistats.StatisticsClient) interface{} {
 		builder.WriteString(clistats.String(totalHosts))
 		builder.WriteRune(' ')
 		builder.WriteRune('(')
-		//nolint:gomnd // this is not a magic number
 		builder.WriteString(clistats.String(uint64(float64(hosts) / float64(totalHosts.(int)) * 100.0)))
 		builder.WriteRune('%')
 		builder.WriteRune(')')


### PR DESCRIPTION
on classical page with alert the browser fall un timeout beacause alert block loading. This pr lead to close alert and take screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot operations now automatically accept unexpected JavaScript dialogs (including those triggered during page load or interaction), preventing interruptions and making captures more reliable. No public APIs or behaviors were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->