### PR TITLE
fix: -allow and -deny flags

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -412,6 +412,11 @@ func (runner *Runner) createNetworkpolicyInstance(options *Options) (*networkpol
 			npOptions.DenyList = append(npOptions.DenyList, exclude)
 		}
 	}
+	
+	// Add Allow and Deny flag integration
+	npOptions.AllowList = append(npOptions.AllowList, options.Allow...)
+	npOptions.DenyList = append(npOptions.DenyList, options.Deny...)
+	
 	np, err := networkpolicy.New(npOptions)
 	return np, err
 }


### PR DESCRIPTION
## Summary

  Fixes non-functional IP filtering in httpx where `-allow` and `-deny` flags were being parsed but never applied to the
  NetworkPolicy instance.

  ## Changes

  - Add missing AllowList and DenyList integration in `createNetworkpolicyInstance()`
  - Add test coverage to validate IP filtering behavior

  ## Problem

  The `-allow` and `-deny` command-line flags were not being passed to the NetworkPolicy instance during initialization,
  causing all IP filtering to be ignored. IPs that should have been blocked were allowed through.

  ## Testing

  Added `TestCreateNetworkpolicyInstance_AllowDenyFlags` which validates:
  - Allow flag correctly blocks IPs outside allowed ranges
  - Deny flag correctly blocks IPs in denied ranges
  - Both flags work independently and together

  ## Examples

  ```bash
  # These now work correctly:
  echo "8.8.8.8" | ./httpx -allow 1.1.1.0/24     # Blocked (not in allowed range)
  echo "8.8.8.8" | ./httpx -deny 8.8.8.0/24      # Blocked (in denied range)
  echo "1.1.1.1" | ./httpx -allow 1.1.1.0/24     # Allowed (in allowed range)