### PR TITLE
fix(runner): Ensure -pr/--protocol flag is correctly applied

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -473,7 +473,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.ChainInStdout, "include-chain", false, "include redirect http chain in JSON output (-json only)"),
 		flagSet.BoolVar(&options.StoreChain, "store-chain", false, "include http redirect chain in responses (-sr only)"),
 		flagSet.BoolVarP(&options.StoreVisionReconClusters, "store-vision-recon-cluster", "svrc", false, "include visual recon clusters (-ss and -sr only)"),
-		flagSet.StringVarP(&options.Protocol, "protocol", "pr", "", "protocol to use (unknown, http11)"),
+		flagSet.StringVarP(&options.Protocol, "protocol", "pr", "", "protocol to use (unknown, http11, http2 [experimental], http3 [experimental])"),
 		flagSet.StringVarP(&options.OutputFilterErrorPagePath, "filter-error-page-path", "fepp", "filtered_error_page.json", "path to store filtered error pages"),
 	)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -177,6 +177,7 @@ func New(options *Options) (*Runner, error) {
 	}
 	httpxOptions.Resolvers = options.Resolvers
 	httpxOptions.TlsImpersonate = options.TlsImpersonate
+	httpxOptions.Protocol = httpx.Proto(options.Protocol)
 
 	var key, value string
 	httpxOptions.CustomHeaders = make(map[string]string)


### PR DESCRIPTION
closes #2233 

###  Description

  This PR fixes a bug where the -pr or --protocol flag was being ignored.

###  Verification

  I verified the fix by adding debug prints to `runner/runner.go` to check that the value of
  `httpx.options.Protocol` is applied correctly.

###  Before

  When running `go run ./cmd/httpx -pr http11 -u example.com`, the flag value was ignored:
``` bash
   httpx.Options.Protocol: 
   Protocol == "http11": false
```

###  After

  With the fix, the same command correctly applies the flag value:
``` bash
   httpx.Options.Protocol: http11
   Protocol == "http11": true
```

  This ensures the command-line flag works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure the selected protocol option is correctly applied during execution (no change to user workflow).

* **Documentation**
  * Updated protocol flag help text to note http2 and http3 are experimental.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->