### PR TITLE
feat: Add auto-referer (HTTP header) option

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -435,6 +435,9 @@ func (h *HTTPX) SetCustomHeaders(r *retryablehttp.Request, headers map[string]st
 		userAgent := useragent.PickRandom()
 		r.Header.Set("User-Agent", userAgent.Raw) //nolint
 	}
+	if h.Options.AutoReferer {
+		r.Header.Set("Referer", r.URL.String())
+	}
 }
 
 func (httpx *HTTPX) setCustomCookies(req *http.Request) {

--- a/common/httpx/option.go
+++ b/common/httpx/option.go
@@ -12,6 +12,7 @@ import (
 // Options contains configuration options for the client
 type Options struct {
 	RandomAgent      bool
+	AutoReferer      bool
 	DefaultUserAgent string
 	Proxy            string
 	// Deprecated: use Proxy

--- a/runner/options.go
+++ b/runner/options.go
@@ -261,6 +261,7 @@ type Options struct {
 	ShowStatistics            bool
 	StatsInterval             int
 	RandomAgent               bool
+	AutoReferer               bool
 	StoreChain                bool
 	StoreVisionReconClusters  bool
 	Deny                      customlist.CustomList
@@ -484,6 +485,7 @@ func ParseOptions() *Options {
 		flagSet.Var(&options.Deny, "deny", "denied list of IP/CIDR's to process (file or comma separated)"),
 		flagSet.StringVarP(&options.SniName, "sni-name", "sni", "", "custom TLS SNI name"),
 		flagSet.BoolVar(&options.RandomAgent, "random-agent", true, "enable Random User-Agent to use"),
+		flagSet.BoolVar(&options.AutoReferer, "auto-referer", false, "set the Referer header to the current URL"),
 		flagSet.VarP(&options.CustomHeaders, "header", "H", "custom http headers to send with request"),
 		flagSet.StringVarP(&options.Proxy, "proxy", "http-proxy", "", "proxy (http|socks) to use (eg http://127.0.0.1:8080)"),
 		flagSet.BoolVar(&options.Unsafe, "unsafe", false, "send raw requests skipping golang normalization"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -168,6 +168,11 @@ func New(options *Options) (*Runner, error) {
 	} else {
 		httpxOptions.RandomAgent = options.RandomAgent
 	}
+	if options.CustomHeaders.Has("Referer:") {
+		httpxOptions.AutoReferer = false
+	} else {
+		httpxOptions.AutoReferer = options.AutoReferer
+	}
 	httpxOptions.ZTLS = options.ZTLS
 	httpxOptions.MaxResponseBodySizeToSave = int64(options.MaxResponseBodySizeToSave)
 	httpxOptions.MaxResponseBodySizeToRead = int64(options.MaxResponseBodySizeToRead)


### PR DESCRIPTION
`httpx` produces better results when the `Referer` header is set. However, when using stdin, there is currently no built-in way to set the `Referer` header based on the current URL.

Normally, we achieve this by using a shell while loop:
`cat links | while read url; do httpx -H "Referer: $url"; done`
This approach is inefficient, as it requires running `httpx` many times, and also using `-threads` is not possible.

This feature introduces the `-auto-referer` option, which eliminates the need for a while loop;
Users can now simply execute: `cat links | httpx -auto-referer`.