### PR TITLE
add custom fingerprint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ PROBES:
    -bp, -body-preview     display first N characters of response body (default 100)
    -server, -web-server   display server name
    -td, -tech-detect      display technology in use based on wappalyzer dataset
+   -cff, -custom-fingerprint-file string  path to a custom fingerprint file for technology detection
    -method                display http request method
    -websocket             display server using websocket
    -ip                    display host ip

--- a/runner/options.go
+++ b/runner/options.go
@@ -257,6 +257,7 @@ type Options struct {
 	NoFallback                bool
 	NoFallbackScheme          bool
 	TechDetect                bool
+	CustomFingerprintFile     string
 	TLSGrab                   bool
 	protocol                  string
 	ShowStatistics            bool
@@ -383,6 +384,7 @@ func ParseOptions() *Options {
 		flagSet.DynamicVarP(&options.ResponseBodyPreviewSize, "body-preview", "bp", 100, "display first N characters of response body"),
 		flagSet.BoolVarP(&options.OutputServerHeader, "web-server", "server", false, "display server name"),
 		flagSet.BoolVarP(&options.TechDetect, "tech-detect", "td", false, "display technology in use based on wappalyzer dataset"),
+		flagSet.StringVarP(&options.CustomFingerprintFile, "custom-fingerprint-file", "cff", "", "path to a custom fingerprint file for technology detection"),
 		flagSet.BoolVar(&options.OutputMethod, "method", false, "display http request method"),
 		flagSet.BoolVar(&options.OutputWebSocket, "websocket", false, "display server using websocket"),
 		flagSet.BoolVar(&options.OutputIP, "ip", false, "display host ip"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -119,7 +119,12 @@ func New(options *Options) (*Runner, error) {
 	if options.Wappalyzer != nil {
 		runner.wappalyzer = options.Wappalyzer
 	} else if options.TechDetect || options.JSONOutput || options.CSVOutput || options.AssetUpload {
-		runner.wappalyzer, err = wappalyzer.New()
+		runner.wappalyzer, err = func() (*wappalyzer.Wappalyze, error) {
+			if options.CustomFingerprintFile != "" {
+				return wappalyzer.NewFromFile(options.CustomFingerprintFile, true, true)
+			}
+			return wappalyzer.New()
+		}()
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create wappalyzer client")


### PR DESCRIPTION
closes https://github.com/projectdiscovery/httpx/issues/1803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a --custom-fingerprint-file (-cff) option to supply a custom fingerprint file for technology detection. When provided, the tool uses the specified fingerprints; default behavior remains unchanged if omitted.

- Documentation
  - Updated PROBES section to document the new -cff/--custom-fingerprint-file option, including its purpose and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->