### PR TITLE
docs: remove redundant usage section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ This will display help for the tool. Here are all the switches it supports.
 
 
 ```console
-Usage:
-  ./httpx [flags]
-
-Flags:
 httpx is a fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library.
 
 Usage:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up the README usage section by simplifying the console code block and removing redundant headers and the invocation line.
  * Improved readability by focusing the example on the descriptive context and reducing visual noise.
  * No changes to features, APIs, or behavior; this is a formatting-only update to make the documentation easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->