### PR TITLE
feat: add shorthand flag for websocket option in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ PROBES:
    -td, -tech-detect      display technology in use based on wappalyzer dataset
    -cff, -custom-fingerprint-file string  path to a custom fingerprint file for technology detection
    -method                display http request method
-   -websocket             display server using websocket
+   -ws, -websocket        display server using websocket
    -ip                    display host ip
    -cname                 display host cname
    -extract-fqdn, -efqdn  get domain and subdomains from response body and header in jsonl/csv output

--- a/runner/options.go
+++ b/runner/options.go
@@ -386,7 +386,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.TechDetect, "tech-detect", "td", false, "display technology in use based on wappalyzer dataset"),
 		flagSet.StringVarP(&options.CustomFingerprintFile, "custom-fingerprint-file", "cff", "", "path to a custom fingerprint file for technology detection"),
 		flagSet.BoolVar(&options.OutputMethod, "method", false, "display http request method"),
-		flagSet.BoolVar(&options.OutputWebSocket, "websocket", false, "display server using websocket"),
+		flagSet.BoolVarP(&options.OutputWebSocket, "websocket", "ws", false, "display server using websocket"),
 		flagSet.BoolVar(&options.OutputIP, "ip", false, "display host ip"),
 		flagSet.BoolVar(&options.OutputCName, "cname", false, "display host cname"),
 		flagSet.BoolVarP(&options.ExtractFqdn, "efqdn", "extract-fqdn", false, "get domain and subdomains from response body and header in jsonl/csv output"),


### PR DESCRIPTION
Adds a shorthand -ws flag for the existing -websocket probe in httpx, improving usability by providing a shorter, convenient alias for checking websocket support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a short -ws alias for the --websocket command-line flag to streamline enabling websocket output. This is fully backward-compatible; existing uses of --websocket continue to work.

* **Documentation**
  * Updated command help and README to include the -ws alias and clarify usage. No functional or runtime behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->