### PR TITLE
fix: ensure Host header is set in unsafe mode for rawhttp requests

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -424,6 +424,9 @@ func (h *HTTPX) SetCustomHeaders(r *retryablehttp.Request, headers map[string]st
 		switch strings.ToLower(name) {
 		case "host":
 			r.Host = value
+			if h.Options.Unsafe {
+				r.Header.Set("Host", value)
+			}
 		case "cookie":
 			// cookies are set in the default branch, and reset during the follow redirect flow
 			fallthrough


### PR DESCRIPTION
fixes #2296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Host header synchronization in unsafe mode to ensure proper header handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->