### PR TITLE
HTTP|HTTPS Port priority optimization

### DIFF
--- a/runner/ports_optimization.go
+++ b/runner/ports_optimization.go
@@ -1,0 +1,33 @@
+package runner
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/projectdiscovery/httpx/common/httpx"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+)
+
+var commonHttpPorts = []string{
+	"80",
+	"8080",
+}
+
+// determineMostLikelySchemeOrder for the input
+func determineMostLikelySchemeOrder(input string) string {
+	if _, port, err := net.SplitHostPort(input); err == nil {
+		// if input has port that is commonly used for HTTP, return http then https
+		if sliceutil.Contains(commonHttpPorts, port) {
+			return httpx.HTTP
+		}
+
+		// As of 10/2025 shodan shows that ports > 1024 are more likely to expose HTTP
+		// hence we test first http then https on higher ports
+		// if input has port > 1024, return http then https
+		if port, err := strconv.Atoi(port); err == nil && port > 1024 {
+			return httpx.HTTP
+		}
+	}
+
+	return httpx.HTTPS
+}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1579,7 +1579,7 @@ func (r *Runner) targets(hp *httpx.HTTPX, target string) chan httpx.Target {
 func (r *Runner) analyze(hp *httpx.HTTPX, protocol string, target httpx.Target, method, origInput string, scanopts *ScanOptions) Result {
 	origProtocol := protocol
 	if protocol == httpx.HTTPorHTTPS || protocol == httpx.HTTPandHTTPS {
-		protocol = httpx.HTTPS
+		protocol = determineMostLikelySchemeOrder(target.Host)
 	}
 	retried := false
 retry:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Embedded nuclei logic for http ports (ref: https://github.com/projectdiscovery/nuclei/pull/6538)

## Release Notes

* **New Features**
  * Intelligent URL scheme detection now infers HTTP or HTTPS based on target port numbers. Common HTTP ports (80, 8080) and ports above 1024 default to HTTP, while others default to HTTPS for improved compatibility and reduced connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->