### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,8 @@ builds:
   main: cmd/httpx/httpx.go
 
 archives:
-- format: zip
+- formats:
+  - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/projectdiscovery/httpx/actions/runs/18838775492/job/53745872660#step:4:24): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```
