### PR TITLE
Improve error handling in htmlToText function

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -25,7 +26,6 @@ import (
 	pdhttputil "github.com/projectdiscovery/utils/http"
 	stringsutil "github.com/projectdiscovery/utils/strings"
 	urlutil "github.com/projectdiscovery/utils/url"
-	"golang.org/x/net/context"
 	"golang.org/x/net/http2"
 )
 

--- a/common/pagetypeclassifier/pagetypeclassifier.go
+++ b/common/pagetypeclassifier/pagetypeclassifier.go
@@ -14,34 +14,23 @@ type PageTypeClassifier struct {
 	classifier *naive_bayes.NaiveBayesClassifier
 }
 
-func New() *PageTypeClassifier {
+func New() (*PageTypeClassifier, error) {
 	classifier, err := naive_bayes.NewClassifierFromFileData(classifierData)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return &PageTypeClassifier{classifier: classifier}
+	return &PageTypeClassifier{classifier: classifier}, nil
 }
 
 func (n *PageTypeClassifier) Classify(html string) string {
-	text := htmlToText(html)
-	if text == "" {
+	text, err := htmlToText(html)
+	if err != nil || text == "" {
 		return "other"
 	}
 	return n.classifier.Classify(text)
 }
 
 // htmlToText safely converts HTML to text and protects against panics from Go's HTML parser.
-func htmlToText(html string) (text string) {
-	defer func() {
-		if r := recover(); r != nil {
-			// Optionally log this event, e.g., log.Printf("Recovered in htmlToText: %v", r)
-			text = ""
-		}
-	}()
-	var err error
-	text, err = htmltomarkdown.ConvertString(html)
-	if err != nil {
-		text = ""
-	}
-	return
+func htmlToText(html string) (string, error) {
+	return htmltomarkdown.ConvertString(html)
 }

--- a/common/pagetypeclassifier/pagetypeclassifier_test.go
+++ b/common/pagetypeclassifier/pagetypeclassifier_test.go
@@ -3,19 +3,22 @@ package pagetypeclassifier
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPageTypeClassifier(t *testing.T) {
 
 	t.Run("test creation of new PageTypeClassifier", func(t *testing.T) {
-		epc := New()
-		assert.NotNil(t, epc)
+		epc, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, epc)
 	})
 
 	t.Run("test classification non error page text", func(t *testing.T) {
-		epc := New()
-		assert.Equal(t, "nonerror", epc.Classify(`<!DOCTYPE html>
+		epc, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, epc)
+		require.Equal(t, "nonerror", epc.Classify(`<!DOCTYPE html>
 		<html lang="en">
 		<head>
 			<meta charset="UTF-8">
@@ -30,8 +33,10 @@ func TestPageTypeClassifier(t *testing.T) {
 	})
 
 	t.Run("test classification on error page text", func(t *testing.T) {
-		epc := New()
-		assert.Equal(t, "error", epc.Classify(`<!DOCTYPE html>
+		epc, err := New()
+		require.NoError(t, err)
+		require.NotNil(t, epc)
+		require.Equal(t, "error", epc.Classify(`<!DOCTYPE html>
 		<html>
 		<head>
 			<title>Error 403: Forbidden</title>

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -385,7 +385,11 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	runner.simHashes = gcache.New[uint64, struct{}](1000).ARC().Build()
-	runner.pageTypeClassifier = pagetypeclassifier.New()
+	pageTypeClassifier, err := pagetypeclassifier.New()
+	if err != nil {
+		return nil, err
+	}
+	runner.pageTypeClassifier = pageTypeClassifier
 
 	if options.HttpApiEndpoint != "" {
 		apiServer := NewServer(options.HttpApiEndpoint, options)


### PR DESCRIPTION
Enhance htmlToText function to handle panics and errors safely.

panic: html: open stack of elements exceeds 512 nodes

goroutine 5523922 [running]:
github.com/projectdiscovery/httpx/common/pagetypeclassifier.htmlToText(...)
	/home/runner/work/httpx/httpx/common/pagetypeclassifier/pagetypeclassifier.go:36
github.com/projectdiscovery/httpx/common/pagetypeclassifier.(*PageTypeClassifier).Classify(0xc0005164d8, {0xc0ba03a000?, 0xd?})
	/home/runner/work/httpx/httpx/common/pagetypeclassifier/pagetypeclassifier.go:26 +0x6f
github.com/projectdiscovery/httpx/runner.(*Runner).analyze(_, _, {_, _}, {{0xc00470c450, 0xb}, {0x0, 0x0}, {0x0, 0x0}}, ...)
	/home/runner/work/httpx/httpx/runner/runner.go:2349 +0x7555
github.com/projectdiscovery/httpx/runner.(*Runner).process.func1({{0xc00470c450, 0xb}, {0x0, 0x0}, {0x0, 0x0}}, {0x1686161?, 0x10?}, {0x16ace2d, 0xa})
	/home/runner/work/httpx/httpx/runner/runner.go:1444 +0x125
created by github.com/projectdiscovery/httpx/runner.(*Runner).process in goroutine 1
	/home/runner/work/httpx/httpx/runner/runner.go:1442 +0x8a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for HTML text conversion to prevent application crashes when conversion errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->