### PR TITLE
feat: update `-ldp` option to show default ports in CLI output

### DIFF
--- a/common/stringz/stringz.go
+++ b/common/stringz/stringz.go
@@ -83,6 +83,14 @@ func AddURLDefaultPort(rawURL string) string {
 	if err != nil {
 		return rawURL
 	}
+	// Force default port to be added if not present
+	if u.Port() == "" {
+		if u.Scheme == urlutil.HTTP {
+			u.UpdatePort("80")
+		} else if u.Scheme == urlutil.HTTPS {
+			u.UpdatePort("443")
+		}
+	}
 	return u.String()
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1723,7 +1723,11 @@ retry:
 	}
 
 	builder := &strings.Builder{}
-	builder.WriteString(stringz.RemoveURLDefaultPort(fullURL))
+	if scanopts.LeaveDefaultPorts {
+		builder.WriteString(stringz.AddURLDefaultPort(fullURL))
+	} else {
+		builder.WriteString(stringz.RemoveURLDefaultPort(fullURL))
+	}
 
 	if r.options.Probe {
 		builder.WriteString(" [")


### PR DESCRIPTION
- Modified URL formatting in runner.go to respect LeaveDefaultPorts option
- Fixed AddURLDefaultPort function to actually add default ports (80/443)
- When -ldp is used, CLI output now shows https://example.com:443 instead of https://example.com
- Maintains backward compatibility - default behavior unchanged

Fixes CLI output inconsistency where -ldp flag only affected Host headers but not the displayed URL in console output.

Closes #2328 

```
~/Github/httpx $ echo example.com | ./httpx -ldp -p http:80 -silent
http://example.com:80

~/Github/httpx $ echo example.com | ./httpx -ldp -p https:443 -silent
https://example.com:443

~/Github/httpx $ echo example.com | ./httpx -ldp -silent
https://example.com:443
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new setting to control default port display behavior in URLs, allowing default ports (80 for HTTP, 443 for HTTPS) to be shown or hidden in output and logs as needed.

* **Bug Fixes**
  * Improved URL formatting logic to consistently apply default ports to URLs lacking explicit port specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->