### PR TITLE
Fix GitHub Actions condition

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: projectdiscovery/actions/setup/go@v1
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v5


### PR DESCRIPTION
Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy.