### PR TITLE
fix: Inconsistent results with probe-all-ips if the port number is set in the URL

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1562,7 +1562,7 @@ func (r *Runner) targets(hp *httpx.HTTPX, target string) chan httpx.Target {
 				results <- httpx.Target{Host: target}
 				return
 			}
-			ips, _, _, err := getDNSData(hp, URL.Host)
+			ips, _, _, err := getDNSData(hp, URL.Hostname())
 			if err != nil || len(ips) == 0 {
 				results <- httpx.Target{Host: target}
 				return

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -67,6 +67,36 @@ func TestRunner_probeall_targets(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not expected output")
 }
 
+func TestRunner_probeall_targets_with_port(t *testing.T) {
+	options := &Options{
+		ProbeAllIPS: true,
+	}
+	r, err := New(options)
+	require.Nil(t, err, "could not create httpx runner")
+
+	inputWithPort := "http://one.one.one.one:8080"
+	inputWithoutPort := "one.one.one.one"
+
+	gotWithPort := []httpx.Target{}
+	for target := range r.targets(r.hp, inputWithPort) {
+		gotWithPort = append(gotWithPort, target)
+	}
+
+	gotWithoutPort := []httpx.Target{}
+	for target := range r.targets(r.hp, inputWithoutPort) {
+		gotWithoutPort = append(gotWithoutPort, target)
+	}
+
+	require.True(t, len(gotWithPort) > 0, "probe-all-ips with port should return at least one target")
+	require.True(t, len(gotWithoutPort) > 0, "probe-all-ips without port should return at least one target")
+	require.Equal(t, len(gotWithPort), len(gotWithoutPort), "probe-all-ips should return same number of IPs with or without port")
+
+	for _, target := range gotWithPort {
+		require.Equal(t, inputWithPort, target.Host, "Host should be preserved with port")
+		require.NotEmpty(t, target.CustomIP, "CustomIP should be populated")
+	}
+}
+
 func TestRunner_cidr_targets(t *testing.T) {
 	options := &Options{}
 	r, err := New(options)
@@ -227,10 +257,10 @@ func TestCreateNetworkpolicyInstance_AllowDenyFlags(t *testing.T) {
 	runner := &Runner{}
 
 	tests := []struct {
-		name        string
-		allow       []string
-		deny        []string
-		testCases   []struct {
+		name      string
+		allow     []string
+		deny      []string
+		testCases []struct {
 			ip       string
 			expected bool
 			reason   string


### PR DESCRIPTION
Fixes #2346

## Changes
- Use URL.Hostname() instead of URL.Host when extracting host for DNS lookup in probe-all-ips mode
- Added test case for probe-all-ips with port in URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DNS lookup logic to generate separate target entries for each resolved IP address while preserving the original hostname. Gracefully falls back to the original target if DNS resolution fails.

* **Tests**
  * Added test coverage for DNS-based target resolution, validating correct behavior with port-included inputs and resolved IP assignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->