### PR TITLE
fix resolver parsing

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -743,11 +743,14 @@ func (options *Options) ValidateOptions() error {
 							resolvers = append(resolvers, item)
 						}
 					}
-				} else {
+				} else if line != "" {
 					resolvers = append(resolvers, line)
 				}
 			}
 		} else {
+			if strings.ContainsAny(resolver, `/\`) {
+				gologger.Warning().Msgf("Resolver argument \"%s\" looks like a file path but the file does not exist", resolver)
+			}
 			resolvers = append(resolvers, resolver)
 		}
 	}


### PR DESCRIPTION
closes https://github.com/projectdiscovery/httpx/issues/2350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Resolver configuration parsing now trims whitespace and accepts comma-separated entries, making multi-value resolver lines easier to write and more forgiving.
  * When a resolver argument appears to be a file path but the file is missing, a warning is logged while still retaining the argument, helping surface potential configuration issues without discarding input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->