### PR TITLE
fix: update Host header for favicon requests after redirects

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2611,6 +2611,10 @@ func (r *Runner) HandleFaviconHash(hp *httpx.HTTPX, req *retryablehttp.Request, 
 		}
 
 		clone.SetURL(resolvedURL)
+		// Update Host header to match resolved URL host (important after redirects)
+		if resolvedURL.Host != "" && resolvedURL.Host != clone.Host {
+			clone.Host = resolvedURL.Host
+		}
 		respFav, err := hp.Do(clone, httpx.UnsafeOptions{})
 		if err != nil || len(respFav.Data) == 0 {
 			tries++


### PR DESCRIPTION
## Summary
- Fix favicon extraction failing when `FollowRedirects` is enabled

## Problem
When using `-favicon -follow-redirects`, the favicon hash is not extracted because:
1. The original request is cloned for fetching favicon URLs
2. After redirect (e.g., `hackerone.com` → `www.hackerone.com`), the favicon URL is correctly resolved to the final host
3. However, the cloned request's Host header still contains the original host
4. The server returns a 404 page because the Host header doesn't match the URL

## Reproduction
```bash
# Without follow-redirects: works
echo "https://hackerone.com" | httpx -favicon -json | jq '.favicon'
# -> "595148549"

# With follow-redirects: fails (returns null)
echo "https://hackerone.com" | httpx -favicon -follow-redirects -json | jq '.favicon'
# -> null
```

##  Fix

Update the Host header to match the resolved URL host before making the favicon request.
```go
// Update Host header to match resolved URL host (important after redirects)
if resolvedURL.Host != "" && resolvedURL.Host != clone.Host {
	clone.Host = resolvedURL.Host
}
```

## Testing
```bash
# After the fix
echo "https://hackerone.com" | httpx -favicon -follow-redirects -json | jq '.favicon'
# -> "172802237"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favicon detection reliability by ensuring HTTP request headers correctly match final redirect targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->