### PR TITLE
fix: add short flag for csv option

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -483,7 +483,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVarP(&options.StoreResponse, "store-response", "sr", false, "store http response to output directory"),
 		flagSet.StringVarP(&options.StoreResponseDir, "store-response-dir", "srd", "", "store http response to custom directory"),
 		flagSet.BoolVarP(&options.OmitBody, "omit-body", "ob", false, "omit response body in output"),
-		flagSet.BoolVar(&options.CSVOutput, "csv", false, "store output in csv format"),
+		flagSet.BoolVarP(&options.CSVOutput, "csv", "c", false, "store output in csv format"),
 		flagSet.StringVarP(&options.CSVOutputEncoding, "csv-output-encoding", "csvo", "", "define output encoding"),
 		flagSet.BoolVarP(&options.JSONOutput, "json", "j", false, "store output in JSONL(ines) format"),
 		flagSet.BoolVarP(&options.ResponseHeadersInStdout, "include-response-header", "irh", false, "include http response (headers) in JSON output (-json only)"),


### PR DESCRIPTION
Fixes #2368

The `-csv` flag was defined without a short form, causing flag parsing issues when used in certain positions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added short flag `-c` as an alias for the `--csv` option to improve command-line usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->