### PR TITLE
fix: respect -pr http11 flag by disabling HTTP/2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,18 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When http11 protocol is explicitly requested, disable HTTP/2 fallback in retryablehttp
+	// by setting HTTPClient2 to use the same HTTP/1.1-only transport. This prevents
+	// retryablehttp from falling back to HTTP/2 when it encounters HTTP/1.x errors.
+	// See: https://github.com/projectdiscovery/httpx/issues/2240
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = &http.Client{
+			Transport:     transport,
+			Timeout:       httpx.Options.Timeout,
+			CheckRedirect: redirectFunc,
+		}
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,39 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+// TestHTTP11ProtocolEnforcement verifies that when http11 protocol is requested,
+// the HTTPClient2 is also configured to use HTTP/1.1 only, preventing fallback to HTTP/2.
+// This is a regression test for https://github.com/projectdiscovery/httpx/issues/2240
+func TestHTTP11ProtocolEnforcement(t *testing.T) {
+	t.Run("http11 protocol disables HTTP/2 fallback", func(t *testing.T) {
+		opts := DefaultOptions
+		opts.Protocol = "http11"
+		ht, err := New(&opts)
+		require.Nil(t, err)
+		require.NotNil(t, ht.client)
+
+		// Verify that HTTPClient2's transport also has TLSNextProto set to disable HTTP/2
+		// When http11 is requested, HTTPClient2 should use the same HTTP/1.1-only transport
+		transport, ok := ht.client.HTTPClient2.Transport.(*http.Transport)
+		require.True(t, ok, "HTTPClient2 should use http.Transport")
+		require.NotNil(t, transport.TLSNextProto, "TLSNextProto should be set to disable HTTP/2")
+		require.Empty(t, transport.TLSNextProto, "TLSNextProto should be empty map to disable HTTP/2")
+	})
+
+	t.Run("default protocol allows HTTP/2 fallback", func(t *testing.T) {
+		opts := DefaultOptions
+		// Don't set Protocol, use default
+		ht, err := New(&opts)
+		require.Nil(t, err)
+		require.NotNil(t, ht.client)
+
+		// In default mode, HTTPClient2 should have HTTP/2 enabled
+		// The transport will have been configured for HTTP/2 by http2.ConfigureTransport
+		_, ok := ht.client.HTTPClient2.Transport.(*http.Transport)
+		// It could be http.Transport (with HTTP/2 configured) or http2.Transport
+		// The important thing is that it's different behavior from http11 mode
+		require.True(t, ok || ht.client.HTTPClient2.Transport != nil,
+			"HTTPClient2 should have a transport configured")
+	})
+}


### PR DESCRIPTION
/claim #2240

## Summary
This PR fixes the issue where the `-pr http11` flag is ignored because retryablehttp-go falls back to HTTP/2 on certain errors.

## Problem
When users specify `-pr http11` to force HTTP/1.1 only connections:
1. httpx correctly sets `TLSNextProto = map[string]func(){}` to disable HTTP/2 on the main transport
2. However, retryablehttp-go's `Client` has a separate `HTTPClient2` field configured for HTTP/2
3. When retryablehttp encounters HTTP/1.x errors like `malformed HTTP version "HTTP/2"`, it falls back to `HTTPClient2` (see [do.go line 62](https://github.com/projectdiscovery/retryablehttp-go/blob/main/do.go#L62))
4. This causes the `-pr http11` flag to be effectively ignored

## Solution
When `http11` protocol is explicitly requested, set `HTTPClient2` to use the same HTTP/1.1-only transport. This ensures the protocol preference is respected throughout the entire request lifecycle, including during retryablehttp's error handling.

## Changes
- Modified `common/httpx/httpx.go`: Set `HTTPClient2` to use HTTP/1.1-only transport when `Protocol == "http11"`
- Added unit test in `common/httpx/httpx_test.go` to verify HTTP/1.1 enforcement

## Testing
- [x] Unit tests pass
- [x] Build succeeds

Fixes #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enforcing HTTP/1.1 protocol when explicitly configured.

* **Tests**
  * Added test coverage to verify HTTP/1.1 protocol enforcement behavior and default protocol handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->