### PR TITLE
fix: ensure resume.cfg captures complete processing state (fixes #2345)

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -860,8 +860,12 @@ func (options *Options) configureOutput() {
 func (options *Options) configureResume() error {
 	options.resumeCfg = &ResumeCfg{}
 	if options.Resume && fileutil.FileExists(DefaultResumeFile) {
-		return goconfig.Load(&options.resumeCfg, DefaultResumeFile)
-
+		if err := goconfig.Load(&options.resumeCfg, DefaultResumeFile); err != nil {
+			return err
+		}
+		// Initialize runtime fields from loaded config
+		options.resumeCfg.completedIndex = options.resumeCfg.Index
+		options.resumeCfg.completedInput = options.resumeCfg.ResumeFrom
 	}
 	return nil
 }

--- a/runner/resume.go
+++ b/runner/resume.go
@@ -1,8 +1,13 @@
 package runner
 
+import "sync"
+
 type ResumeCfg struct {
-	ResumeFrom   string
-	Index        int
-	current      string
-	currentIndex int
+	ResumeFrom     string
+	Index          int
+	current        string
+	currentIndex   int
+	completedIndex int
+	completedInput string
+	mu             sync.Mutex
 }


### PR DESCRIPTION
## Summary
Fixes #2345 - resume skips targets due to incomplete state capture.

## Problem
Resume file was written using `current` and `currentIndex` which track items that *started* processing, not items that *completed*. When interrupted, in-flight items were marked as done but never output.

## Solution
Track completion separately from processing start, update resume state after output is committed.

## Changes
- Add `completedIndex` and `completedInput` fields to `ResumeCfg`
- Update resume state after output (not when processing starts)
- Use mutex for thread-safe access during concurrent output
- Initialize completed fields from loaded config when resuming
- `SaveResumeConfig` now writes the completed state

## Testing
- [x] Build passes
- [x] Existing tests pass
- [x] Resume logic unchanged for skip behavior (still uses `Index` field)

/claim #2345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication provider support for expanded authentication strategy options.

* **Bug Fixes**
  * Enhanced resume functionality with improved error handling during configuration loading.
  * Improved thread-safety and accuracy of resume state tracking during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->