### PR TITLE
fix(httpx): honor -pr http11 by disabling HTTP/2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -182,6 +182,10 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
+	if httpx.Options.Protocol == "http11" {
+		// Explicitly prevent retryablehttp from falling back to a native HTTP/2 client.
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -13,7 +14,14 @@ func TestDo(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("content-length in header", func(t *testing.T) {
-		req, err := retryablehttp.NewRequest(http.MethodGet, "https://scanme.sh", nil)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body := []byte("OK")
+			w.Header().Set("Content-Length", "2")
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		req, err := retryablehttp.NewRequest(http.MethodGet, server.URL, nil)
 		require.Nil(t, err)
 		resp, err := ht.Do(req, UnsafeOptions{})
 		require.Nil(t, err)
@@ -21,10 +29,33 @@ func TestDo(t *testing.T) {
 	})
 
 	t.Run("content-length with binary body", func(t *testing.T) {
-		req, err := retryablehttp.NewRequest(http.MethodGet, "https://www.w3schools.com/images/favicon.ico", nil)
+		binary := make([]byte, 1024)
+		for i := range binary {
+			binary[i] = byte(i % 256)
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Length", "1024")
+			_, _ = w.Write(binary)
+		}))
+		defer server.Close()
+
+		req, err := retryablehttp.NewRequest(http.MethodGet, server.URL, nil)
 		require.Nil(t, err)
 		resp, err := ht.Do(req, UnsafeOptions{})
 		require.Nil(t, err)
 		require.Greater(t, len(resp.Raw), 800)
+		require.Equal(t, len(binary), resp.ContentLength)
 	})
+}
+
+func TestHTTP11DisablesHTTP2Fallback(t *testing.T) {
+	options := DefaultOptions
+	options.Protocol = HTTP11
+
+	ht, err := New(&options)
+	require.NoError(t, err)
+	require.NotNil(t, ht.client)
+
+	// When protocol is http11, retryablehttp should not use a separate HTTP/2 fallback client.
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
 }


### PR DESCRIPTION
Fixes #2240
/claim #2240

## What
When running with `-pr http11`, httpx configures its transport for HTTP/1.1, but retryablehttp-go can still fall back to a native HTTP/2 client on certain malformed HTTP/2 errors, bypassing the explicit protocol selection.

## Change
- When `Options.Protocol == http11`, explicitly pin retryablehttp's `HTTPClient2` to `HTTPClient` so fallback cannot switch protocols.
- Update unit tests to be fully offline (replace external URLs with `httptest` servers).

## Proof
```bash
GOCACHE=/tmp/gocache-httpx go test ./common/httpx -count=1
ok   github.com/projectdiscovery/httpx/common/httpx  1.689s
```

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * HTTP/1.1 protocol selection now explicitly disables HTTP/2 fallback.

* **Tests**
  * Enhanced test coverage for HTTP/1.1 protocol behavior with improved test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->