### PR TITLE
fix: prevent HTTP/2 fallback when -pr http11 is set

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,18 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When HTTP/1.1 is explicitly requested, override the retryablehttp fallback
+	// client (HTTPClient2) to also use the HTTP/1.1-only transport. Without this,
+	// retryablehttp falls back to HTTPClient2 (which has HTTP/2 enabled) when it
+	// encounters "malformed HTTP version" errors, silently ignoring the -pr http11 flag.
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = &http.Client{
+			Transport:     transport,
+			Timeout:       httpx.Options.Timeout,
+			CheckRedirect: redirectFunc,
+		}
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
## Summary

When using `-pr http11`, httpx correctly disables HTTP/2 on the primary transport by clearing `TLSNextProto`. However, retryablehttp-go maintains a separate internal client (`HTTPClient2`) with HTTP/2 enabled, which it silently falls back to whenever the HTTP/1.1 request fails with a "malformed HTTP version" error from HTTP/2-only servers. This means the `-pr http11` flag has no effect against servers that only speak HTTP/2.

The fix overrides `HTTPClient2` on the retryablehttp client with an HTTP/1.1-only client after construction, so the fallback path also uses the same protocol-restricted transport.

## Root Cause

In `retryablehttp-go/do.go`, the retry loop catches HTTP/1.x transport errors caused by servers responding with HTTP/2 and transparently retries the request using `HTTPClient2`, which has `http2.ConfigureTransport` applied. This second client completely bypasses the transport configuration that httpx set up to enforce HTTP/1.1. Since `HTTPClient2` is a public field on the retryablehttp `Client` struct, the simplest fix is to replace it with a client that shares the same HTTP/1.1 transport.

## Changes

- `common/httpx/httpx.go`: After creating the retryablehttp client, when `Protocol == "http11"`, replace `HTTPClient2` with a new `http.Client` that uses the same HTTP/1.1-only transport (with `TLSNextProto` cleared). This ensures retryablehttp's internal fallback path does not upgrade to HTTP/2.

## Test plan

- All existing tests pass (`go test ./...`, `go vet ./...`)
- Verified by reading the retryablehttp-go source that the fallback in `do.go` line 63-66 uses `HTTPClient2.Do()`, and this change ensures that client is now constrained to HTTP/1.1 when requested

Fixes #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the HTTP/1.1 protocol flag was not consistently enforced across fallback clients, preventing silent fallback to HTTP/2 when explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->