### PR TITLE
fix: respect -pr http11 flag by disabling HTTP/2 fallback in retryablehttp

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,17 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When HTTP/1.1 is explicitly requested, also disable HTTP/2 fallback
+	// in the retryablehttp client's secondary HTTP client to prevent
+	// automatic HTTP/2 upgrade on retry (see retryablehttp-go do.go).
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = &http.Client{
+			Transport:     transport,
+			Timeout:       httpx.Options.Timeout,
+			CheckRedirect: redirectFunc,
+		}
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
## Description

Fixes #2240

When the user specifies `-pr http11`, httpx correctly disables HTTP/2 on the primary transport by:
1. Setting `GODEBUG=http2client=0`
2. Setting `transport.TLSNextProto` to an empty map

However, `retryablehttp-go`'s internal `HTTPClient2` (used as a fallback when HTTP/1.x encounters malformed HTTP/2 responses in [`do.go:63-64`](https://github.com/projectdiscovery/retryablehttp-go/blob/main/do.go#L63)) still has HTTP/2 enabled via `http2.ConfigureTransport`. This silently upgrades connections to HTTP/2 and defeats the `-pr http11` flag.

## Fix

After creating the retryablehttp client, when `Protocol == "http11"`, override `HTTPClient2` to use the same HTTP/1.1-only transport. This ensures no HTTP/2 fallback occurs at any level.

## Changes

- `common/httpx/httpx.go`: Set `HTTPClient2` to use the HTTP/1.1-only transport when `-pr http11` is specified

## Verification

Before (with `-pr http11`):
- retryablehttp detects HTTP/1.x error → falls back to HTTPClient2 (HTTP/2 enabled) → connection upgraded to HTTP/2

After (with `-pr http11`):
- retryablehttp detects HTTP/1.x error → falls back to HTTPClient2 (HTTP/2 disabled) → stays on HTTP/1.1