### PR TITLE
fix(httpx): honor -pr http11 by disabling retryablehttp h2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -182,6 +182,11 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
+	if httpx.Options.Protocol == HTTP11 {
+		// retryablehttp client retries malformed HTTP/2 responses with HTTPClient2.
+		// Keep both clients on the same HTTP/1.1 transport when protocol is forced.
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -182,25 +182,27 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
-	if httpx.Options.Protocol == HTTP11 {
-		// retryablehttp client retries malformed HTTP/2 responses with HTTPClient2.
-		// Keep both clients on the same HTTP/1.1 transport when protocol is forced.
-		httpx.client.HTTPClient2 = httpx.client.HTTPClient
-	}
 
-	transport2 := &http2.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-			MinVersion:         tls.VersionTLS10,
-		},
-		AllowHTTP: true,
-	}
-	if httpx.Options.SniName != "" {
-		transport2.TLSClientConfig.ServerName = httpx.Options.SniName
-	}
-	httpx.client2 = &http.Client{
-		Transport: transport2,
-		Timeout:   httpx.Options.Timeout,
+	// honor explicit HTTP/1.1 mode by disabling retryablehttp-go's internal
+	// HTTP/2 fallback client and HTTPX's own HTTP/2 probing client
+	if httpx.Options.Protocol == HTTP11 {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+		httpx.client2 = httpx.client.HTTPClient
+	} else {
+		transport2 := &http2.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS10,
+			},
+			AllowHTTP: true,
+		}
+		if httpx.Options.SniName != "" {
+			transport2.TLSClientConfig.ServerName = httpx.Options.SniName
+		}
+		httpx.client2 = &http.Client{
+			Transport: transport2,
+			Timeout:   httpx.Options.Timeout,
+		}
 	}
 
 	httpx.htmlPolicy = bluemonday.NewPolicy()

--- a/common/httpx/httpx_protocol_test.go
+++ b/common/httpx/httpx_protocol_test.go
@@ -1,0 +1,26 @@
+package httpx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTP11DisablesRetryableHTTP2FallbackClient(t *testing.T) {
+	options := DefaultOptions
+	options.Protocol = HTTP11
+
+	h, err := New(&options)
+	require.NoError(t, err)
+	require.NotNil(t, h.client)
+	require.Same(t, h.client.HTTPClient, h.client.HTTPClient2)
+}
+
+func TestNewDefaultKeepsRetryableHTTP2FallbackClient(t *testing.T) {
+	options := DefaultOptions
+
+	h, err := New(&options)
+	require.NoError(t, err)
+	require.NotNil(t, h.client)
+	require.NotSame(t, h.client.HTTPClient, h.client.HTTPClient2)
+}

--- a/common/httpx/httpx_protocol_test.go
+++ b/common/httpx/httpx_protocol_test.go
@@ -3,24 +3,37 @@ package httpx
 import (
 	"testing"
 
+	"golang.org/x/net/http2"
+
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewHTTP11DisablesRetryableHTTP2FallbackClient(t *testing.T) {
-	options := DefaultOptions
-	options.Protocol = HTTP11
+func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
 
-	h, err := New(&options)
+	ht, err := New(&opts)
 	require.NoError(t, err)
-	require.NotNil(t, h.client)
-	require.Same(t, h.client.HTTPClient, h.client.HTTPClient2)
+	require.NotNil(t, ht)
+	t.Cleanup(func() { ht.Dialer.Close() })
+	require.NotNil(t, ht.client)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+	require.Same(t, ht.client.HTTPClient, ht.client2)
+	_, isHTTP2 := ht.client2.Transport.(*http2.Transport)
+	require.False(t, isHTTP2)
 }
 
-func TestNewDefaultKeepsRetryableHTTP2FallbackClient(t *testing.T) {
-	options := DefaultOptions
+func TestNew_NonHTTP11KeepsRetryableHTTP2FallbackClient(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP2
 
-	h, err := New(&options)
+	ht, err := New(&opts)
 	require.NoError(t, err)
-	require.NotNil(t, h.client)
-	require.NotSame(t, h.client.HTTPClient, h.client.HTTPClient2)
+	require.NotNil(t, ht)
+	t.Cleanup(func() { ht.Dialer.Close() })
+	require.NotNil(t, ht.client)
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+	require.NotSame(t, ht.client.HTTPClient, ht.client2)
+	_, isHTTP2 := ht.client2.Transport.(*http2.Transport)
+	require.True(t, isHTTP2)
 }


### PR DESCRIPTION
Fixes #2240

/claim #2240

## Summary
- Prevent retryablehttp from silently falling back to HTTP/2 when `-pr http11` is set.
- Keep normal fallback behavior for non-http11 mode.

## Why
When users explicitly force HTTP/1.1, protocol fallback to HTTP/2 violates expectation and can bypass transport policy differences.

## Validation
- `GOTOOLCHAIN=auto go test ./common/httpx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure HTTP/1.1 mode fully disables HTTP/2 fallback so both client paths use the same HTTP/1.1 behavior, avoiding unintended HTTP/2 transport usage.

* **Tests**
  * Added tests confirming HTTP/1.1 enforcement prevents HTTP/2 fallback and that non-HTTP/1.1 protocols retain HTTP/2 fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->