### PR TITLE
fix: honor -pr http11 by disabling retryable HTTP/2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,12 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When HTTP/1.1 is explicitly requested, prevent retryablehttp from
+	// falling back to HTTP/2 on malformed response retries.
+	if httpx.Options.Protocol == "http11" && httpx.client != nil {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/projectdiscovery/retryablehttp-go"
 	"github.com/stretchr/testify/require"
@@ -27,4 +28,28 @@ func TestDo(t *testing.T) {
 		require.Nil(t, err)
 		require.Greater(t, len(resp.Raw), 800)
 	})
+}
+
+func TestHTTP11DisablesRetryHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Timeout = 2 * time.Second
+	opts.Protocol = "http11"
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotNil(t, ht.client)
+	require.NotNil(t, ht.client.HTTPClient)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}
+
+func TestDefaultProtocolKeepsDedicatedHTTP2Client(t *testing.T) {
+	opts := DefaultOptions
+	opts.Timeout = 2 * time.Second
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotNil(t, ht.client)
+	require.NotNil(t, ht.client.HTTPClient)
+	require.NotNil(t, ht.client.HTTPClient2)
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2)
 }


### PR DESCRIPTION
## Proposed Changes
- when `-pr http11` is selected, force retryablehttp to reuse the same HTTP/1.1 client for fallback retries
- this prevents retryablehttp from switching to its dedicated HTTP/2 client on malformed HTTP version errors
- add focused unit tests to verify:
  - HTTP/1.1 mode uses the same client for `HTTPClient` and `HTTPClient2`
  - default mode still keeps a dedicated HTTP/2 fallback client

## Proof
```bash
go test ./common/httpx -run 'TestHTTP11DisablesRetryHTTP2Fallback|TestDefaultProtocolKeepsDedicatedHTTP2Client' -count=1
ok  github.com/projectdiscovery/httpx/common/httpx  0.593s
```

## Checklist
- [x] PR created against the correct branch (`dev`)
- [x] Targeted tests passed
- [x] Tests added for the behavior change
- [ ] Documentation updated (not required for this internal behavior fix)

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTTP/1.1 request handling to prevent unintended fallback to HTTP/2 when HTTP/1.1 is explicitly requested, ensuring consistent protocol usage during retries.

* **Tests**
  * Added test coverage for HTTP/1.1 protocol enforcement and HTTP/2 client configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->