### PR TITLE
fix(httpx): honor -pr http11 in h2 probe client

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -153,7 +153,7 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
 		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
@@ -185,7 +185,7 @@ func New(options *Options) (*HTTPX, error) {
 
 	// honor explicit HTTP/1.1 mode by disabling retryablehttp-go's internal
 	// HTTP/2 fallback client and HTTPX's own HTTP/2 probing client
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		httpx.client.HTTPClient2 = httpx.client.HTTPClient
 		httpx.client2 = httpx.client.HTTPClient
 	} else {

--- a/common/httpx/httpx_protocol_test.go
+++ b/common/httpx/httpx_protocol_test.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"os"
 	"testing"
 
 	"golang.org/x/net/http2"
@@ -11,6 +12,15 @@ import (
 func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP11
+
+	originalGODEBUG, hadGODEBUG := os.LookupEnv("GODEBUG")
+	t.Cleanup(func() {
+		if hadGODEBUG {
+			_ = os.Setenv("GODEBUG", originalGODEBUG)
+		} else {
+			_ = os.Unsetenv("GODEBUG")
+		}
+	})
 
 	ht, err := New(&opts)
 	require.NoError(t, err)

--- a/common/httpx/httpx_protocol_test.go
+++ b/common/httpx/httpx_protocol_test.go
@@ -1,0 +1,39 @@
+package httpx
+
+import (
+	"testing"
+
+	"golang.org/x/net/http2"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotNil(t, ht)
+	t.Cleanup(func() { ht.Dialer.Close() })
+	require.NotNil(t, ht.client)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+	require.Same(t, ht.client.HTTPClient, ht.client2)
+	_, isHTTP2 := ht.client2.Transport.(*http2.Transport)
+	require.False(t, isHTTP2)
+}
+
+func TestNew_NonHTTP11KeepsRetryableHTTP2FallbackClient(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP2
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotNil(t, ht)
+	t.Cleanup(func() { ht.Dialer.Close() })
+	require.NotNil(t, ht.client)
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+	require.NotSame(t, ht.client.HTTPClient, ht.client2)
+	_, isHTTP2 := ht.client2.Transport.(*http2.Transport)
+	require.True(t, isHTTP2)
+}

--- a/common/httpx/httpx_protocol_test.go
+++ b/common/httpx/httpx_protocol_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestNew_HTTP11DisablesRetryableHTTP2Fallback verifies that forcing HTTP/1.1 disables retryablehttp-go's HTTP/2 fallback and prevents HTTP/2 probing client creation.
 func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP11
@@ -33,6 +34,7 @@ func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	require.False(t, isHTTP2)
 }
 
+// TestNew_NonHTTP11KeepsRetryableHTTP2FallbackClient verifies that non-HTTP/1.1 mode keeps a dedicated HTTP/2 client2 transport and allows retryable fallback behavior.
 func TestNew_NonHTTP11KeepsRetryableHTTP2FallbackClient(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP2


### PR DESCRIPTION
Follow-up to #2414 and issue #2240.

This patch ensures explicit `-pr http11` is honored across both retry fallback and HTTP/2 probe paths:

- sets `httpx.client2 = httpx.client.HTTPClient` in HTTP11 mode
- keeps dedicated HTTP/2 client only when protocol is not forced to HTTP11
- adds/updates tests for both behaviors
- adds dialer cleanup via `t.Cleanup` in protocol tests

Validation:

```bash
go test ./common/httpx -run TestNew_ -count=1
```

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP/1.1 mode now disables HTTP/2 fallback and routes both client paths through a single shared client.
  * Protocol selection controls whether a dedicated HTTP/2 transport is created or skipped.

* **Tests**
  * Added unit tests verifying shared-client behavior for HTTP/1.1 and dedicated HTTP/2 transport for non-HTTP/1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->