### PR TITLE
fix(http11): disable HTTP/2 fallback for -pr http11 (Fixes #2240)

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -77,6 +77,9 @@ func New(options *Options) (*HTTPX, error) {
 	retryablehttpOptions.Timeout = httpx.Options.Timeout
 	retryablehttpOptions.RetryMax = httpx.Options.RetryMax
 	retryablehttpOptions.Trace = options.Trace
+	if httpx.Options.Protocol == HTTP11 {
+		retryablehttpOptions.DisableHTTPFallback = true
+	}
 	handleHSTS := func(req *http.Request) {
 		if req.Response.Header.Get("Strict-Transport-Security") == "" {
 			return


### PR DESCRIPTION
Fixes #2240

Summary:
- When Protocol is forced to HTTP/1.1 ("-pr http11"), set retryablehttp-go option DisableHTTPFallback to prevent switching to the internal HTTP/2 fallback client on malformed HTTP/2 responses.

Note:
- This PR depends on projectdiscovery/retryablehttp-go PR #527 (adds Options.DisableHTTPFallback).
- Until that PR is merged and a module version is available, CI may fail due to the missing field.

Tests (local, with temporary module replace):
- go test ./common/httpx -count=1

/claim #2240