### PR TITLE
fix: respect -pr http11 flag by preventing HTTP/2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -153,7 +153,7 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
 		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
@@ -182,6 +182,12 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
+	// When HTTP/1.1 is explicitly requested, prevent retryablehttp-go from
+	// falling back to its internal HTTP/2 client on malformed protocol errors.
+	// See: https://github.com/projectdiscovery/httpx/issues/2240
+	if httpx.Options.Protocol == HTTP11 {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -153,6 +153,11 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
+	// Protocol enforcement is split into two blocks: this one disables HTTP/2 at
+	// the transport level before the client is constructed; the second block
+	// (below, after httpx.client is initialised) redirects the retryablehttp-go
+	// fallback client so it cannot re-upgrade to HTTP/2 on malformed-protocol
+	// errors. Both checks are required because neither alone is sufficient.
 	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
 		_ = os.Setenv("GODEBUG", "http2client=0")
@@ -185,6 +190,8 @@ func New(options *Options) (*HTTPX, error) {
 	// When HTTP/1.1 is explicitly requested, prevent retryablehttp-go from
 	// falling back to its internal HTTP/2 client on malformed protocol errors.
 	// See: https://github.com/projectdiscovery/httpx/issues/2240
+	// TODO: replace this alias with a DisableHTTPFallback option once
+	// retryablehttp-go exposes one upstream (#2240).
 	if httpx.Options.Protocol == HTTP11 {
 		httpx.client.HTTPClient2 = httpx.client.HTTPClient
 	}

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,26 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+func TestHTTP11DisablesHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+
+	ht, err := New(&opts)
+	require.Nil(t, err)
+
+	// When http11 is requested, HTTPClient2 must point to the same client
+	// as HTTPClient so retryablehttp-go's fallback path does not switch to HTTP/2.
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		"HTTPClient2 should equal HTTPClient when Protocol is HTTP11")
+}
+
+func TestDefaultProtocolKeepsHTTP2Fallback(t *testing.T) {
+	ht, err := New(&DefaultOptions)
+	require.Nil(t, err)
+
+	// By default the two clients must remain separate so that the HTTP/2
+	// fallback in retryablehttp-go works as designed.
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		"HTTPClient2 should differ from HTTPClient by default")
+}

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -9,7 +10,8 @@ import (
 )
 
 func TestDo(t *testing.T) {
-	ht, err := New(&DefaultOptions)
+	opts := DefaultOptions
+	ht, err := New(&opts)
 	require.Nil(t, err)
 
 	t.Run("content-length in header", func(t *testing.T) {
@@ -33,7 +35,10 @@ func TestHTTP11DisablesHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP11
 
+	// Capture GODEBUG before New() sets it; t.Setenv restores it after the test.
+	prev := os.Getenv("GODEBUG")
 	ht, err := New(&opts)
+	t.Setenv("GODEBUG", prev)
 	require.Nil(t, err)
 
 	// When http11 is requested, HTTPClient2 must point to the same client
@@ -43,7 +48,8 @@ func TestHTTP11DisablesHTTP2Fallback(t *testing.T) {
 }
 
 func TestDefaultProtocolKeepsHTTP2Fallback(t *testing.T) {
-	ht, err := New(&DefaultOptions)
+	opts := DefaultOptions
+	ht, err := New(&opts)
 	require.Nil(t, err)
 
 	// By default the two clients must remain separate so that the HTTP/2

--- a/common/httpx/proto.go
+++ b/common/httpx/proto.go
@@ -1,10 +1,15 @@
 package httpx
 
+// Proto identifies the HTTP protocol version to use for requests.
 type Proto string
 
 const (
+	// UNKNOWN leaves the protocol unspecified, letting the client negotiate.
 	UNKNOWN Proto = ""
-	HTTP11  Proto = "http11"
-	HTTP2   Proto = "http2"
-	HTTP3   Proto = "http3"
+	// HTTP11 enforces HTTP/1.1 and disables HTTP/2 negotiation.
+	HTTP11 Proto = "http11"
+	// HTTP2 requests HTTP/2 for all connections.
+	HTTP2 Proto = "http2"
+	// HTTP3 requests HTTP/3 (QUIC) for all connections.
+	HTTP3 Proto = "http3"
 )


### PR DESCRIPTION
## Proposed changes

Fixes #2240
/claim #2240

When `-pr http11` is set, httpx disables HTTP/2 on the main transport but retryablehttp-go still falls back to its internal `HTTPClient2` (configured with HTTP/2) whenever it encounters malformed HTTP version errors in `do.go`. This effectively ignores the user's protocol preference.

This patch points `HTTPClient2` to the same HTTP/1.1 client when `Protocol == HTTP11`, so the fallback path stays on HTTP/1.1. Also replaces the string literal with the existing `HTTP11` constant.

### Proof

```
$ go test ./common/httpx/ -run 'TestHTTP11|TestDefaultProtocol' -v -race -count=1
=== RUN   TestHTTP11DisablesHTTP2Fallback
--- PASS: TestHTTP11DisablesHTTP2Fallback (0.17s)
=== RUN   TestDefaultProtocolKeepsHTTP2Fallback
--- PASS: TestDefaultProtocolKeepsHTTP2Fallback (0.20s)
PASS
ok  github.com/projectdiscovery/httpx/common/httpx  2.104s
```

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/httpx/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended HTTP/2 fallback when HTTP/1.1 is explicitly selected, ensuring consistent protocol behavior and avoiding protocol upgrades on certain network errors.

* **Tests**
  * Added tests verifying that HTTP/1.1 selection disables HTTP/2 fallback and that default settings retain HTTP/2 fallback.

* **Documentation**
  * Added descriptive comments clarifying protocol type constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->