### PR TITLE
fix: enforce -pr http11 across retry fallback path

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -182,6 +182,10 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
+	if httpx.Options.Protocol == HTTP11 {
+		// Keep retryablehttp-go on HTTP/1.1 as well when it retries internally.
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -153,9 +152,8 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
-		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	}
 

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -152,7 +152,7 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == HTTP11 {
+	if isHTTP11Protocol(httpx.Options.Protocol) {
 		// disable http2
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 	}
@@ -180,7 +180,7 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
-	if httpx.Options.Protocol == HTTP11 {
+	if isHTTP11Protocol(httpx.Options.Protocol) {
 		// Keep retryablehttp-go on HTTP/1.1 as well when it retries internally.
 		httpx.client.HTTPClient2 = httpx.client.HTTPClient
 	}
@@ -212,6 +212,10 @@ func New(options *Options) (*HTTPX, error) {
 	}
 
 	return httpx, nil
+}
+
+func isHTTP11Protocol(protocol Proto) bool {
+	return strings.EqualFold(string(protocol), string(HTTP11))
 }
 
 // Do http request

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -38,6 +38,15 @@ func TestHTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
 }
 
+func TestHTTP11MixedCaseDisablesRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = Proto("HTTP11")
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}
+
 func TestDefaultProtocolKeepsRetryableHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,12 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+func TestHTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -32,6 +33,19 @@ func TestDo(t *testing.T) {
 func TestHTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP11
+
+	originalGODEBUG, hadGODEBUG := os.LookupEnv("GODEBUG")
+	t.Cleanup(func() {
+		if hadGODEBUG {
+			if err := os.Setenv("GODEBUG", originalGODEBUG); err != nil {
+				t.Fatalf("failed to restore GODEBUG: %v", err)
+			}
+			return
+		}
+		if err := os.Unsetenv("GODEBUG"); err != nil {
+			t.Fatalf("failed to unset GODEBUG: %v", err)
+		}
+	})
 
 	ht, err := New(&opts)
 	require.NoError(t, err)

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -2,7 +2,6 @@ package httpx
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -34,20 +33,15 @@ func TestHTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
 	opts := DefaultOptions
 	opts.Protocol = HTTP11
 
-	originalGODEBUG, hadGODEBUG := os.LookupEnv("GODEBUG")
-	t.Cleanup(func() {
-		if hadGODEBUG {
-			if err := os.Setenv("GODEBUG", originalGODEBUG); err != nil {
-				t.Fatalf("failed to restore GODEBUG: %v", err)
-			}
-			return
-		}
-		if err := os.Unsetenv("GODEBUG"); err != nil {
-			t.Fatalf("failed to unset GODEBUG: %v", err)
-		}
-	})
-
 	ht, err := New(&opts)
 	require.NoError(t, err)
 	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}
+
+func TestDefaultProtocolKeepsRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2)
 }


### PR DESCRIPTION
## Proposed Changes

This PR keeps `-pr http11` deterministic by preventing retry fallback from switching protocol unexpectedly, while keeping change scope minimal.

### What changed
- In `common/httpx/httpx.go`:
  - use `HTTP11` constant for protocol gating
  - disable HTTP/2 at transport scope via `TLSNextProto` in HTTP/1.1 mode
  - avoid mutating process-wide `GODEBUG` in client initialization
  - keep retry fallback on the same HTTP/1.1-configured client when `-pr http11` is requested:
    - `httpx.client.HTTPClient2 = httpx.client.HTTPClient`
- In `common/httpx/httpx_test.go`:
  - `TestHTTP11DisablesRetryableHTTP2Fallback`
  - `TestDefaultProtocolKeepsRetryableHTTP2Fallback`

### Why this approach
`retryablehttp-go` fallback path currently calls `HTTPClient2` on malformed HTTP/2 framing errors. For explicit HTTP/1.1 mode, this patch keeps fallback on the HTTP/1.1 client path and avoids protocol drift.

## Proof

```bash
go test ./common/httpx -run 'TestHTTP11DisablesRetryableHTTP2Fallback|TestDefaultProtocolKeepsRetryableHTTP2Fallback' -count=1
go test ./common/httpx -count=1
```

## Checklist

- [x] PR created against `dev`
- [x] Tests added/updated for regression coverage
- [x] Local validation run
- [x] `/claim #2240` included

Ref: #2240

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal retry logic now preserves an explicitly selected HTTP/1.1 protocol so retries no longer fall back to HTTP/2.

* **Tests**
  * Added test coverage validating HTTP/1.1 enforcement, mixed-case protocol handling, and default protocol fallback behavior.

* **Refactor**
  * Minor internal cleanup to simplify protocol detection and initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->