### PR TITLE
fix: disable HTTP/2 fallback when using HTTP/1.1 only mode

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -77,6 +77,12 @@ func New(options *Options) (*HTTPX, error) {
 	retryablehttpOptions.Timeout = httpx.Options.Timeout
 	retryablehttpOptions.RetryMax = httpx.Options.RetryMax
 	retryablehttpOptions.Trace = options.Trace
+
+	// Disable HTTP/2 fallback when using HTTP/1.1 only mode
+	if httpx.Options.Protocol == "http11" {
+		retryablehttpOptions.DisableHTTPFallback = true
+	}
+
 	handleHSTS := func(req *http.Request) {
 		if req.Response.Header.Get("Strict-Transport-Security") == "" {
 			return

--- a/go.mod
+++ b/go.mod
@@ -178,3 +178,5 @@ require (
 	golang.org/x/tools v0.41.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+
+replace github.com/projectdiscovery/retryablehttp-go => github.com/bigeric08/retryablehttp-go v1.3.6

--- a/go.mod.replace
+++ b/go.mod.replace
@@ -1,0 +1,1 @@
+replace github.com/projectdiscovery/retryablehttp-go => github.com/bigeric08/retryablehttp-go v1.3.6


### PR DESCRIPTION
## Problem
When using `-pr http11` flag to enforce HTTP/1.1, the flag is ignored because retryablehttp-go falls back to HTTP/2 on malformed HTTP errors.

## Solution
- Add DisableHTTPFallback option to retryablehttp-go
- Modify do.go to check this option before falling back to HTTP/2
- Update httpx to use DisableHTTPFallback when Protocol is http11

Fixes: #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced HTTP/1.1 protocol configuration handling to ensure proper compliance with selected protocol settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->