### PR TITLE
fix: disable HTTP/2 fallback when http11 flag is set (#2240)

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,11 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	if httpx.Options.Protocol == "http11" {
+		// disable HTTP/2 fallback in retryablehttp-go
+		httpx.client.HTTPClient2 = nil
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
Fixes #2240

When the `-pr http11` flag is set, httpx now properly disables HTTP/2 fallback in retryablehttp-go by setting `HTTPClient2` to nil after client initialization.

This prevents retryablehttp-go from automatically falling back to HTTP/2 when encountering malformed HTTP version errors, ensuring that the http11 protocol flag is respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP/1.1 protocol enforcement to prevent unintended fallback to HTTP/2 when HTTP/1.1 is explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->