### PR TITLE
fix(httpx): keep retry fallback on HTTP/1.1 when -pr http11 is set

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -153,7 +153,7 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
 		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
@@ -182,6 +182,10 @@ func New(options *Options) (*HTTPX, error) {
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
+
+	if httpx.Options.Protocol == HTTP11 {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,22 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+func TestHTTP11DisablesRetryableHTTP2FallbackClient(t *testing.T) {
+	options := DefaultOptions
+	options.Protocol = HTTP11
+
+	ht, err := New(&options)
+	require.NoError(t, err)
+	require.NotNil(t, ht.client)
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}
+
+func TestDefaultProtocolKeepsRetryableHTTP2FallbackClient(t *testing.T) {
+	options := DefaultOptions
+
+	ht, err := New(&options)
+	require.NoError(t, err)
+	require.NotNil(t, ht.client)
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}


### PR DESCRIPTION
## Proposed changes

Fixes #2240
/claim #2240

- Fixes `-pr http11` bypass on retry fallback path.
- Uses `HTTP11` constant instead of string literal in protocol check.
- In HTTP/1.1 mode, forces retry fallback client to use the same client:
  - `HTTPClient2 = HTTPClient`
- Adds regression tests:
  - `TestHTTP11DisablesRetryableHTTP2FallbackClient`
  - `TestDefaultProtocolKeepsRetryableHTTP2FallbackClient`


### Proof

#### 1) Unit tests

```bash
go test ./common/httpx -run 'TestHTTP11DisablesRetryableHTTP2FallbackClient|TestDefaultProtocolKeepsRetryableHTTP2FallbackClient' -count=1
go test ./common/httpx -count=1
```

<img width="1309" height="269" alt="image" src="https://github.com/user-attachments/assets/6bf2a1c7-96d0-4518-bb6f-03d7d82b120b" />

#### 2) Runtime proof (before vs after)

Minimal runtime harness prints one key signal:

```go
// key check printed by runtime harness
fmt.Printf("%s protocol=%q same_httpclient2=%t\n", label, opts.Protocol, client.HTTPClient == client.HTTPClient2)
```

Run against **before** code (clean tree):

Output (before):
<img width="490" height="131" alt="image" src="https://github.com/user-attachments/assets/256452b5-8ae2-40d3-9cbe-7daf0f34cba9" />

Run against **after** code (this PR branch):

Output (after):
<img width="596" height="91" alt="image" src="https://github.com/user-attachments/assets/3af09553-ccbd-4567-a9d3-992f4aeccb9b" />


#### 3) CLI live run against local PoC server

PoC server: `/tmp/httpx-poc-server` (listens on `https://127.0.0.1:8443`)

Run (before binary):

```bash
SSL_CERT_FILE=/tmp/httpx-poc-ca.pem /tmp/httpx-base.bin -u https://127.0.0.1:8443 -pr http11 -status-code -debug -retries 2 -timeout 5
```

<img width="1232" height="370" alt="image" src="https://github.com/user-attachments/assets/9a67ba71-d493-4e78-b62d-310d8992dea9" />

Run (after binary):

```bash
SSL_CERT_FILE=/tmp/httpx-poc-ca.pem /tmp/httpx-patched.bin -u https://127.0.0.1:8443 -pr http11 -status-code -debug -retries 2 -timeout 5
```

<img width="1100" height="394" alt="image" src="https://github.com/user-attachments/assets/35e8926a-8a79-47b9-8b03-e061a114bf9d" />

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/httpx/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/1.1 protocol handling to ensure HTTP/2 is properly disabled when HTTP/1.1 is explicitly selected, providing more reliable protocol enforcement.

* **Tests**
  * Added test coverage to verify HTTP/1.1 protocol behavior and client configuration under different protocol settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->