### PR TITLE
fix(http11): disable retryable HTTP/2 fallback path

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,10 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = nil
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,13 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+func TestHTTP11ShouldDisableRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = "http11"
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+
+	require.Nil(t, ht.client.HTTPClient2, "when protocol is http11, retryablehttp HTTPClient2 fallback should be disabled")
+}


### PR DESCRIPTION
## Proposed Changes

Honor explicit `-pr http11` intent by disabling retryable HTTP/2 fallback client in httpx.

- Keep existing HTTP/1.1 enforcement in transport (`GODEBUG=http2client=0` + `TLSNextProto` override).
- Additionally set `httpx.client.HTTPClient2 = nil` when protocol is `http11` so retryablehttp-go cannot silently switch to HTTP/2 fallback path.
- Add regression test `TestHTTP11ShouldDisableRetryableHTTP2Fallback`.

## Proof

### Repro/failing behavior before fix
Added test:

```go
func TestHTTP11ShouldDisableRetryableHTTP2Fallback(t *testing.T) {
  opts := DefaultOptions
  opts.Protocol = "http11"
  ht, _ := New(&opts)
  require.Nil(t, ht.client.HTTPClient2)
}
```

Before fix:
```bash
go test ./common/httpx -run "HTTP11ShouldDisableRetryableHTTP2Fallback" -count=1
--- FAIL: TestHTTP11ShouldDisableRetryableHTTP2Fallback
Expected nil, but got: &http.Client{...}
```

After fix:
```bash
go test ./common/httpx -run "HTTP11ShouldDisableRetryableHTTP2Fallback" -count=1
ok  github.com/projectdiscovery/httpx/common/httpx

go test ./common/httpx -count=1
ok  github.com/projectdiscovery/httpx/common/httpx
```

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/1.1 protocol handling to correctly disable HTTP/2 client fallback when configured for HTTP/1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->