### PR TITLE
fix(-pr http11): disable retryablehttp HTTP/2 fallback when http11 protocol is forced

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -154,9 +154,13 @@ func New(options *Options) (*HTTPX, error) {
 	}
 
 	if httpx.Options.Protocol == "http11" {
-		// disable http2
+		// disable http2 at transport level
 		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+		// also disable the HTTP/2 fallback in retryablehttp-go so that
+		// malformed-HTTP/2 errors do not cause a silent protocol upgrade
+		// via HTTPClient2 (see projectdiscovery/retryablehttp-go#532)
+		retryablehttpOptions.DisableHTTP2Fallback = true
 	}
 
 	if httpx.Options.SniName != "" {


### PR DESCRIPTION
## Problem

When `-pr http11` is used, httpx correctly disables HTTP/2 at the transport level:

```go
_ = os.Setenv("GODEBUG", "http2client=0")
transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
```

However, retryablehttp-go has an automatic fallback in `do.go` that silently upgrades to HTTP/2 when it sees a malformed HTTP/2 error:

```go
if err != nil && stringsutil.ContainsAny(err.Error(), "net/http: HTTP/1.x transport connection broken...") {
    resp, err = c.HTTPClient2.Do(req.Request)  // bypasses http11 config!
}
```

This means `-pr http11` has no effect for servers that respond with HTTP/2, because retryablehttp-go overrides the protocol choice via `HTTPClient2`.

Fixes #2240

## Fix

This PR sets `retryablehttpOptions.DisableHTTP2Fallback = true` when `Protocol == "http11"`, which (via projectdiscovery/retryablehttp-go#532) skips the `HTTPClient2.Do` fallback and honours the HTTP/1.1-only requirement end-to-end.

## Dependency

Requires projectdiscovery/retryablehttp-go#532 to be merged first (adds the `DisableHTTP2Fallback` option).

## Testing

```bash
# Before: http11 flag has no effect, server upgrades to HTTP/2
httpx -u https://example.com -pr http11 -debug 2>&1 | grep -i protocol

# After: request stays on HTTP/1.1
httpx -u https://example.com -pr http11 -debug 2>&1 | grep -i protocol
```