### PR TITLE
fix(runner): add mutex to testAndSet to prevent race condition

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -80,6 +80,7 @@ import (
 
 // Runner is a client for running the enumeration process.
 type Runner struct {
+	seenMux sync.Mutex
 	options            *Options
 	hp                 *httpx.HTTPX
 	wappalyzer         *wappalyzer.Wappalyze
@@ -675,6 +676,9 @@ func (r *Runner) classifyPage(headlessBody, body string, pHash uint64) map[strin
 }
 
 func (r *Runner) testAndSet(k string) bool {
+	r.seenMux.Lock()
+	defer r.seenMux.Unlock()
+
 	// skip empty lines
 	k = strings.TrimSpace(k)
 	if k == "" {

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -322,6 +323,67 @@ func TestRunner_CSVRow(t *testing.T) {
 	if strings.Contains(csvOutput, "'200") {
 		t.Error("CSV sanitization incorrectly modified non-vulnerable field")
 	}
+}
+
+func TestRunner_testAndSet(t *testing.T) {
+	r, err := New(&Options{})
+	require.Nil(t, err, "could not create httpx runner")
+
+	t.Run("first insert returns true", func(t *testing.T) {
+		require.True(t, r.testAndSet("example.com"))
+	})
+
+	t.Run("duplicate returns false", func(t *testing.T) {
+		require.False(t, r.testAndSet("example.com"))
+	})
+
+	t.Run("different key returns true", func(t *testing.T) {
+		require.True(t, r.testAndSet("other.com"))
+	})
+
+	t.Run("empty string returns false", func(t *testing.T) {
+		require.False(t, r.testAndSet(""))
+	})
+
+	t.Run("whitespace-only returns false", func(t *testing.T) {
+		require.False(t, r.testAndSet("   "))
+	})
+
+	t.Run("trimmed duplicate returns false", func(t *testing.T) {
+		require.False(t, r.testAndSet("  example.com  "))
+	})
+}
+
+func TestRunner_testAndSet_concurrent(t *testing.T) {
+	r, err := New(&Options{})
+	require.Nil(t, err, "could not create httpx runner")
+
+	const goroutines = 100
+	key := "race-target.com"
+	wins := make([]bool, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			wins[idx] = r.testAndSet(key)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	winCount := 0
+	for _, w := range wins {
+		if w {
+			winCount++
+		}
+	}
+	require.Equal(t, 1, winCount, "exactly one goroutine should win testAndSet for the same key")
 }
 
 func TestCreateNetworkpolicyInstance_AllowDenyFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a race condition in `testAndSet` where the read-check-then-write sequence is not atomic.

## Problem

`testAndSet` performs:
1. `seen(k)` - check if key exists
2. `setSeen(k)` - set the key

Without synchronization, two concurrent goroutines can both pass the `seen()` check before either calls `setSeen()`, causing duplicate processing of the same target.

## Impact

This race occurs in `processTargets()` where multiple goroutines call `testAndSet()` for discovered TLS SubjectAN/SubjectCN values (lines 1692, 1697, 1706, 1746, 1751).

When the race triggers:
- Same target gets processed multiple times
- Duplicate output entries
- Wasted HTTP requests and resources

## Fix

Add a `sync.Mutex` to the Runner struct to serialize `testAndSet` operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the robustness of the deduplication system to ensure consistent behavior during concurrent operations.

* **Tests**
  * Added comprehensive unit tests for the deduplication method, including concurrent execution scenarios to validate correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->