### PR TITLE
fix(http11): pin retry fallback to HTTP/1.1 transport

### DIFF
--- a/common/httpx/http11_fallback_test.go
+++ b/common/httpx/http11_fallback_test.go
@@ -1,0 +1,23 @@
+package httpx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_HTTP11DisablesRetryableHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+
+	ht, err := New(&opts)
+	require.NoError(t, err)
+	require.NotNil(t, ht)
+	require.NotNil(t, ht.client)
+	require.NotNil(t, ht.client.HTTPClient)
+	require.NotNil(t, ht.client.HTTPClient2)
+
+	// Protocol pinning expectation: when forced to HTTP/1.1, retry fallback should
+	// stay on the same client/transport instead of switching to dedicated HTTP/2.
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,13 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When protocol is explicitly forced to HTTP/1.1, prevent retryablehttp from
+	// falling back to its dedicated HTTP/2 client path on malformed HTTP/2 errors.
+	// Keep retries enabled, but pinned to the same HTTP/1.1 transport settings.
+	if httpx.Options.Protocol == HTTP11 {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,


### PR DESCRIPTION
## Summary
This PR fixes #2240 by ensuring `-pr http11` remains protocol-pinned even on retry fallback paths.

## Problem
When HTTP/1.1 is forced, retryablehttp could still switch to its `HTTPClient2` fallback on malformed HTTP/2 errors, which breaks explicit protocol pinning expectations.

## Solution
- Keep existing HTTP/1.1 transport hardening (`GODEBUG=http2client=0` + `TLSNextProto` disable).
- Additionally pin retry fallback to the same HTTP/1.1 client when `Protocol == HTTP11`:
  - `httpx.client.HTTPClient2 = httpx.client.HTTPClient`

This preserves retry behavior while preventing unintended protocol upgrade fallback.

## Tests
Added unit test:
- `TestNew_HTTP11DisablesRetryableHTTP2Fallback`

Local verification:
- `go test ./common/httpx -run TestNew_HTTP11DisablesRetryableHTTP2Fallback -count=1`
- `go test ./common/httpx -count=1`

/claim #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP/1.1 protocol pinning to prevent unintended fallback to HTTP/2 when explicitly requested while maintaining retry and connection reuse capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->