### PR TITLE
fix: preserve -pr http11 retry behavior (#2240)

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,11 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	if httpx.Options.Protocol == "http11" {
+		// keep retry fallback on the same client so explicit HTTP/1.1 is preserved
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -455,3 +460,7 @@ func (httpx *HTTPX) Sanitize(respStr string, trimLine, normalizeSpaces bool) str
 	}
 	return respStr
 }
+
+
+
+

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -28,3 +28,13 @@ func TestDo(t *testing.T) {
 		require.Greater(t, len(resp.Raw), 800)
 	})
 }
+
+func TestHTTP11ProtocolDisablesHTTP2FallbackClient(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+
+	ht, err := New(&opts)
+	require.Nil(t, err)
+	require.NotNil(t, ht.client)
+	require.Equal(t, ht.client.HTTPClient, ht.client.HTTPClient2)
+}


### PR DESCRIPTION
/claim #2240

## Proposed Changes
- preserve explicit -pr http11 by preventing retry fallback from switching to a separate HTTP/2-capable client
- add a focused regression test for HTTP/1.1 mode

## Proof
- go test ./common/httpx -run TestHTTP11ProtocolDisablesHTTP2FallbackClient -v (pass)

## Checklist
- [x] narrow scope
- [x] tests included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP/1.1 protocol mode to properly disable HTTP/2 fallback, ensuring connections consistently use the explicitly configured HTTP/1.1 protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->