### PR TITLE
fix(http11): prevent retryablehttp HTTP/2 fallback from bypassing -pr http11 (#2240)

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,15 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When HTTP/1.1-only mode is enforced, prevent retryablehttp-go's HTTP/2 fallback
+	// from bypassing the protocol restriction. retryablehttp-go falls back to HTTPClient2
+	// (an HTTP/2-capable client) when it encounters a "malformed HTTP version" error from
+	// a server that speaks HTTP/2. Replacing HTTPClient2 with the HTTP/1.1-only HTTPClient
+	// ensures the -pr http11 flag is honoured end-to-end. See: #2240
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/projectdiscovery/retryablehttp-go"
@@ -12,6 +13,7 @@ import (
 // HTTP/2 fallback from bypassing the HTTP/1.1-only restriction (#2240).
 func TestHTTP11ProtocolEnforcement(t *testing.T) {
 	t.Run("http11 mode disables HTTPClient2 fallback", func(t *testing.T) {
+		t.Setenv("GODEBUG", os.Getenv("GODEBUG"))
 		opts := DefaultOptions
 		opts.Protocol = "http11"
 		ht, err := New(&opts)
@@ -19,17 +21,18 @@ func TestHTTP11ProtocolEnforcement(t *testing.T) {
 
 		// When Protocol == "http11", HTTPClient2 must point to the same underlying
 		// client as HTTPClient so the retryablehttp-go fallback is neutralised.
-		require.Equal(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2,
 			"HTTPClient2 must equal HTTPClient in http11 mode to prevent HTTP/2 fallback")
 	})
 
 	t.Run("default mode keeps distinct HTTPClient2", func(t *testing.T) {
+		t.Setenv("GODEBUG", os.Getenv("GODEBUG"))
 		ht, err := New(&DefaultOptions)
 		require.Nil(t, err)
 
 		// Without an explicit http11 restriction the two clients must differ
 		// (HTTPClient2 is the native HTTP/2 client used for protocol detection).
-		require.NotEqual(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2,
 			"HTTPClient2 must be distinct from HTTPClient in default mode")
 	})
 }

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestHTTP11ProtocolEnforcement verifies that -pr http11 prevents the retryablehttp-go
+// HTTP/2 fallback from bypassing the HTTP/1.1-only restriction (#2240).
+func TestHTTP11ProtocolEnforcement(t *testing.T) {
+	t.Run("http11 mode disables HTTPClient2 fallback", func(t *testing.T) {
+		opts := DefaultOptions
+		opts.Protocol = "http11"
+		ht, err := New(&opts)
+		require.Nil(t, err)
+
+		// When Protocol == "http11", HTTPClient2 must point to the same underlying
+		// client as HTTPClient so the retryablehttp-go fallback is neutralised.
+		require.Equal(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+			"HTTPClient2 must equal HTTPClient in http11 mode to prevent HTTP/2 fallback")
+	})
+
+	t.Run("default mode keeps distinct HTTPClient2", func(t *testing.T) {
+		ht, err := New(&DefaultOptions)
+		require.Nil(t, err)
+
+		// Without an explicit http11 restriction the two clients must differ
+		// (HTTPClient2 is the native HTTP/2 client used for protocol detection).
+		require.NotEqual(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+			"HTTPClient2 must be distinct from HTTPClient in default mode")
+	})
+}
+
 func TestDo(t *testing.T) {
 	ht, err := New(&DefaultOptions)
 	require.Nil(t, err)


### PR DESCRIPTION
## Root Cause

When `-pr http11` is specified, httpx correctly disables HTTP/2 on the main transport:
- Sets `GODEBUG=http2client=0`
- Clears `transport.TLSNextProto`

However, `retryablehttp-go`'s `do.go` has an unconditional fallback at line 63–64:

```go
if err != nil && stringsutil.ContainsAny(err.Error(), "malformed HTTP version \"HTTP/2\"", ...) {
    resp, err = c.HTTPClient2.Do(req.Request)
}
```

`HTTPClient2` is a separate `*http.Client` configured with `golang.org/x/net/http2.ConfigureTransport`. Because it is set independently of the HTTP/1.1-only `HTTPClient`, this fallback silently bypasses the `-pr http11` restriction whenever a server responds with HTTP/2 framing.

## Fix

After constructing the `retryablehttp` client, when `Protocol == "http11"`, replace its `HTTPClient2` with the already-configured HTTP/1.1-only `HTTPClient`:

```go
if httpx.Options.Protocol == "http11" {
    httpx.client.HTTPClient2 = httpx.client.HTTPClient
}
```

This ensures the retryablehttp fallback also honours the HTTP/1.1-only constraint without requiring any upstream changes to `retryablehttp-go` and without affecting `client2`/`SupportHTTP2` for non-restricted clients.

## Tests

Added `TestHTTP11ProtocolEnforcement` with two sub-tests:

1. `http11 mode disables HTTPClient2 fallback` — asserts `HTTPClient2 == HTTPClient` when `Protocol == "http11"`
2. `default mode keeps distinct HTTPClient2` — asserts the two clients differ in default mode

```
=== RUN   TestHTTP11ProtocolEnforcement
=== RUN   TestHTTP11ProtocolEnforcement/http11_mode_disables_HTTPClient2_fallback
--- PASS (0.07s)
=== RUN   TestHTTP11ProtocolEnforcement/default_mode_keeps_distinct_HTTPClient2
--- PASS (0.05s)
--- PASS: TestHTTP11ProtocolEnforcement (0.12s)
PASS
```

## Checklist

- [x] Targets `dev` branch
- [x] Minimal change — only applies when `Protocol == "http11"`
- [x] No upstream retryablehttp-go changes required
- [x] Unit tests pass
- [x] `go build ./...` passes
- [x] Fixes #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures HTTP/1.1 mode is consistently enforced during HTTP client setup, preventing unintended HTTP/2 fallbacks.

* **Tests**
  * Added test coverage to validate HTTP/1.1 enforcement and to confirm default protocol behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->