### PR TITLE
fix: respect -pr http11 flag by disabling HTTP/2 fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -177,11 +177,22 @@ func New(options *Options) (*HTTPX, error) {
 		transport.Proxy = http.ProxyURL(proxyURL)
 	}
 
-	httpx.client = retryablehttp.NewWithHTTPClient(&http.Client{
+	httpClient := &http.Client{
 		Transport:     transport,
 		Timeout:       httpx.Options.Timeout,
 		CheckRedirect: redirectFunc,
-	}, retryablehttpOptions)
+	}
+	httpx.client = retryablehttp.NewWithHTTPClient(httpClient, retryablehttpOptions)
+
+	// When HTTP/1.1-only mode is requested, the retryablehttp-go library still
+	// has an internal fallback (HTTPClient2) that retries with a native HTTP/2
+	// client when it encounters certain error messages about malformed HTTP/2
+	// responses. Override that fallback client with the same HTTP/1.1 transport
+	// so the -pr http11 flag is respected throughout the entire request
+	// lifecycle, including retries.
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = httpClient
+	}
 
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{


### PR DESCRIPTION
## Summary

When users specify `-pr http11` to force HTTP/1.1-only connections, httpx correctly disables HTTP/2 on the primary transport via `transport.TLSNextProto = map[string]...{}`. However, `retryablehttp-go`'s fallback mechanism silently retries failed requests with an HTTP/2-capable client (`HTTPClient2`), effectively bypassing the explicit protocol restriction.

This means `-pr http11` is **not actually enforced** — any target that returns malformed HTTP/1.x responses triggers an automatic HTTP/2 retry through a completely separate client that ignores the user's protocol preference.

## Root Cause

In `retryablehttp-go/do.go`, the `Do()` method contains:

```go
if err != nil && stringsutil.ContainsAny(err.Error(),
    "net/http: HTTP/1.x transport connection broken: malformed HTTP version \"HTTP/2\"",
    "net/http: HTTP/1.x transport connection broken: malformed HTTP response") {
    resp, err = c.HTTPClient2.Do(req.Request)  // ← bypasses -pr http11
}
```

`HTTPClient2` is initialized internally with `http2.ConfigureTransport()`, making it HTTP/2-capable regardless of the user's `-pr` flag.

## Fix

After creating the retryablehttp client with the HTTP/1.1-only `*http.Client`, override the fallback `HTTPClient2` with the same client when `Protocol == "http11"`:

```go
if httpx.Options.Protocol == "http11" {
    httpx.client.HTTPClient2 = httpClient
}
```

This ensures the `-pr http11` flag is respected end-to-end, including during the HTTP/2 fallback path in retries.

## Test plan

- [x] `-pr http11` against an HTTP/2-only server: requests fail cleanly instead of silently upgrading
- [x] Default mode (no `-pr` flag): HTTP/2 fallback works as before (no behavioral change)
- [x] `-pr http2` mode: unaffected
- [x] Retry behavior: retries use the protocol-restricted client consistently

## Related

- Root cause in retryablehttp-go: projectdiscovery/retryablehttp-go#3
- Fix is in httpx (consumer) to avoid a breaking change in the library API

Fixes #2240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured HTTP client initialization for improved code organization and maintainability
  * Enhanced HTTP/1.1 protocol handling during network retry operations to ensure consistent protocol behavior is preserved throughout the entire retry process
  * No changes to the public API—existing integrations will work as before

<!-- end of auto-generated comment: release notes by coderabbit.ai -->