### PR TITLE
fix: prevent nil panic for unsafe HEAD requests

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -224,11 +224,11 @@ get_response:
 	}
 
 	var shouldIgnoreErrors, shouldIgnoreBodyErrors bool
-	switch {
-	case h.Options.Unsafe && req.Method == http.MethodHead && !stringsutil.ContainsAny(err.Error(), "i/o timeout"):
+	if h.Options.Unsafe && req.Method == http.MethodHead && err != nil &&
+		!stringsutil.ContainsAny(err.Error(), "i/o timeout") {
 		shouldIgnoreErrors = true
 		shouldIgnoreBodyErrors = true
-	}
+	 }
 
 	var resp Response
 	resp.Input = req.Host

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -228,7 +228,7 @@ get_response:
 		!stringsutil.ContainsAny(err.Error(), "i/o timeout") {
 		shouldIgnoreErrors = true
 		shouldIgnoreBodyErrors = true
-	 }
+	}
 
 	var resp Response
 	resp.Input = req.Host


### PR DESCRIPTION
**Description:**
- **Problem:** When running `httpx` with `--unsafe` and sending a `HEAD` request, `Do()` could panic due to dereferencing `err` when it was `nil` (`err.Error()` was called even on success).
- **Fix:** Guard the `err.Error()` call by requiring `err != nil` before accessing it.

Fixes #2458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined HTTP error-ignoring behavior to more precisely handle certain unsafe HEAD responses, reducing false positives when suppressing errors.
  * Retains existing exclusion for I/O timeout messages to avoid masking genuine network timeouts, improving request stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->