### PR TITLE
fix: respect -pr http11 during retryablehttp fallback

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -183,6 +183,13 @@ func New(options *Options) (*HTTPX, error) {
 		CheckRedirect: redirectFunc,
 	}, retryablehttpOptions)
 
+	// When http11 is forced, override HTTPClient2 to also use the HTTP/1.1-only
+	// transport. Without this, retryablehttp silently falls back to HTTPClient2
+	// (which has HTTP/2 enabled) on certain transport errors, bypassing -pr http11.
+	if httpx.Options.Protocol == "http11" {
+		httpx.client.HTTPClient2 = httpx.client.HTTPClient
+	}
+
 	transport2 := &http2.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -153,7 +153,7 @@ func New(options *Options) (*HTTPX, error) {
 		DisableKeepAlives: true,
 	}
 
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		// disable http2
 		_ = os.Setenv("GODEBUG", "http2client=0")
 		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
@@ -186,7 +186,7 @@ func New(options *Options) (*HTTPX, error) {
 	// When http11 is forced, override HTTPClient2 to also use the HTTP/1.1-only
 	// transport. Without this, retryablehttp silently falls back to HTTPClient2
 	// (which has HTTP/2 enabled) on certain transport errors, bypassing -pr http11.
-	if httpx.Options.Protocol == "http11" {
+	if httpx.Options.Protocol == HTTP11 {
 		httpx.client.HTTPClient2 = httpx.client.HTTPClient
 	}
 

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -13,14 +13,14 @@ func TestHTTP11ProtocolDisablesHTTP2Fallback(t *testing.T) {
 	opts.Protocol = HTTP11
 	ht, err := New(&opts)
 	require.Nil(t, err)
-	require.Equal(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+	require.Same(t, ht.client.HTTPClient, ht.client.HTTPClient2,
 		"HTTPClient2 should equal HTTPClient when Protocol is HTTP11")
 }
 
 func TestDefaultProtocolKeepsHTTP2Fallback(t *testing.T) {
 	ht, err := New(&DefaultOptions)
 	require.Nil(t, err)
-	require.NotEqual(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+	require.NotSame(t, ht.client.HTTPClient, ht.client.HTTPClient2,
 		"HTTPClient2 should differ from HTTPClient with default protocol")
 }
 

--- a/common/httpx/httpx_test.go
+++ b/common/httpx/httpx_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHTTP11ProtocolDisablesHTTP2Fallback(t *testing.T) {
+	opts := DefaultOptions
+	opts.Protocol = HTTP11
+	ht, err := New(&opts)
+	require.Nil(t, err)
+	require.Equal(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		"HTTPClient2 should equal HTTPClient when Protocol is HTTP11")
+}
+
+func TestDefaultProtocolKeepsHTTP2Fallback(t *testing.T) {
+	ht, err := New(&DefaultOptions)
+	require.Nil(t, err)
+	require.NotEqual(t, ht.client.HTTPClient, ht.client.HTTPClient2,
+		"HTTPClient2 should differ from HTTPClient with default protocol")
+}
+
 func TestDo(t *testing.T) {
 	ht, err := New(&DefaultOptions)
 	require.Nil(t, err)


### PR DESCRIPTION
/claim #2240
Closes #2240

Summary

When `-pr http11` is specified, httpx should strictly use HTTP/1.1.

However, retryablehttp may fall back to HTTPClient2 (which has HTTP/2 enabled)
on certain transport errors, bypassing the user's explicit protocol selection.

## Fix

If HTTP/1.1 is forced, ensure HTTPClient2 reuses the same HTTP/1.1-only client,
preventing unintended HTTP/2 fallback.

## Impact

- Respects explicit protocol selection
- Prevents silent HTTP/2 usage
- Minimal and safe change

## Testing

Verified locally:

- go build ./...
- ./httpx -u https://example.com -pr http11 -debug
- ./httpx -u https://nghttp2.org -pr http11 -debug
- ./httpx -u https://cloudflare.com -pr http11 -debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced HTTP/1.1 for configured client connections so primary and retry clients share the same transport, preventing unexpected protocol fallback during retries.

* **Tests**
  * Added tests confirming that HTTP/1.1 configuration disables protocol fallback and that default settings preserve the existing retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->