### PR TITLE
feat: add security.txt detection flag

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -254,6 +254,7 @@ type Options struct {
 	OutputIP                  bool
 	OutputCName               bool
 	ExtractFqdn               bool
+	SecurityTxt               bool
 	Unsafe                    bool
 	Debug                     bool
 	DebugRequests             bool
@@ -417,6 +418,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.OutputIP, "ip", false, "display host ip"),
 		flagSet.BoolVar(&options.OutputCName, "cname", false, "display host cname"),
 		flagSet.BoolVarP(&options.ExtractFqdn, "efqdn", "extract-fqdn", false, "get domain and subdomains from response body and header in jsonl/csv output"),
+		flagSet.BoolVar(&options.SecurityTxt, "security-txt", false, "detect a valid security.txt file on standard paths"),
 		flagSet.BoolVar(&options.Asn, "asn", false, "display host asn information"),
 		flagSet.DynamicVar(&options.OutputCDN, "cdn", "true", "display cdn/waf in use"),
 		flagSet.BoolVar(&options.Probe, "probe", false, "display probe status"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -330,6 +330,15 @@ func New(options *Options) (*Runner, error) {
 	scanopts.VHostInput = options.VHostInput
 	scanopts.OutputContentType = options.OutputContentType
 	scanopts.RequestBody = options.RequestBody
+	if options.SecurityTxt {
+		options.OutputMatchString = append(options.OutputMatchString, "Contact:")
+		options.OutputMatchStatusCode = appendCommaSeparatedValue(options.OutputMatchStatusCode, "200")
+		options.RequestURIs = appendCommaSeparatedValue(options.RequestURIs, "/.well-known/security.txt,/security.txt")
+		options.JSONOutput = true
+	}
+	if options.RequestURIs != "" {
+		options.requestURIs = normalizeRequestURIs(options.RequestURIs)
+	}
 	scanopts.Unsafe = options.Unsafe
 	scanopts.Pipeline = options.Pipeline
 	scanopts.HTTP2Probe = options.HTTP2Probe
@@ -2632,6 +2641,11 @@ retry:
 		}
 	}
 
+	securityTxt := false
+	if r.options.SecurityTxt {
+		securityTxt = isSecurityTxt(resp)
+	}
+
 	result := Result{
 		Timestamp:        time.Now(),
 		Request:          request,
@@ -2650,6 +2664,7 @@ retry:
 		StatusCode:       resp.StatusCode,
 		Location:         resp.GetHeaderPart("Location", ";"),
 		ContentType:      resp.GetHeaderPart("Content-Type", ";"),
+		SecurityTxt:      securityTxt,
 		Title:            title,
 		str:              builder.String(),
 		VHost:            isvhost,
@@ -2971,6 +2986,48 @@ func (r Result) CSVRow(scanopts *ScanOptions) string { //nolint
 	}
 
 	return res
+}
+
+func appendCommaSeparatedValue(current string, values string) string {
+	current = strings.TrimSpace(current)
+	values = strings.TrimSpace(values)
+	if current == "" {
+		return values
+	}
+	if values == "" {
+		return current
+	}
+	return current + "," + values
+}
+
+func normalizeRequestURIs(requestURIs string) []string {
+	items := stringsutil.SplitAny(requestURIs, ",")
+	cleaned := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		cleaned = append(cleaned, item)
+	}
+	return cleaned
+}
+
+func isSecurityTxt(resp *httpx.Response) bool {
+	if resp == nil || resp.StatusCode != 200 {
+		return false
+	}
+	contentType := strings.ToLower(resp.GetHeaderPart("Content-Type", ";"))
+	if contentType != "" && !strings.Contains(contentType, "text/plain") {
+		return false
+	}
+	body := string(resp.RawData)
+	return strings.Contains(body, "Contact:")
 }
 
 func (r *Runner) skipCDNPort(host string, port string) bool {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -2988,6 +2988,8 @@ func (r Result) CSVRow(scanopts *ScanOptions) string { //nolint
 	return res
 }
 
+// appendCommaSeparatedValue appends comma-separated values to an existing
+// comma-separated string, handling empty inputs gracefully.
 func appendCommaSeparatedValue(current string, values string) string {
 	current = strings.TrimSpace(current)
 	values = strings.TrimSpace(values)
@@ -3000,6 +3002,8 @@ func appendCommaSeparatedValue(current string, values string) string {
 	return current + "," + values
 }
 
+// normalizeRequestURIs splits a comma-separated URI string into a deduplicated,
+// trimmed slice preserving first-occurrence order.
 func normalizeRequestURIs(requestURIs string) []string {
 	items := stringsutil.SplitAny(requestURIs, ",")
 	cleaned := make([]string, 0, len(items))
@@ -3018,6 +3022,8 @@ func normalizeRequestURIs(requestURIs string) []string {
 	return cleaned
 }
 
+// isSecurityTxt validates whether an HTTP response represents a valid security.txt
+// file: HTTP 200, text/plain content type, and a Contact field present in the body.
 func isSecurityTxt(resp *httpx.Response) bool {
 	if resp == nil || resp.StatusCode != 200 {
 		return false

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -286,6 +286,63 @@ func TestRunner_urlWithComma_targets(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not expected output")
 }
 
+func TestNormalizeRequestURIs(t *testing.T) {
+	got := normalizeRequestURIs("/.well-known/security.txt, /security.txt, /.well-known/security.txt,,")
+	require.Equal(t, []string{"/.well-known/security.txt", "/security.txt"}, got)
+}
+
+func TestAppendCommaSeparatedValue(t *testing.T) {
+	require.Equal(t, "200", appendCommaSeparatedValue("", "200"))
+	require.Equal(t, "200,302", appendCommaSeparatedValue("200", "302"))
+	require.Equal(t, "200", appendCommaSeparatedValue("200", ""))
+}
+
+func TestIsSecurityTxt(t *testing.T) {
+	t.Run("valid security txt", func(t *testing.T) {
+		resp := &httpx.Response{
+			StatusCode: 200,
+			Headers: map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			},
+			RawData: []byte("Contact: mailto:security@example.com\nExpires: 2027-01-01T00:00:00.000Z\n"),
+		}
+		require.True(t, isSecurityTxt(resp))
+	})
+
+	t.Run("soft 404 html", func(t *testing.T) {
+		resp := &httpx.Response{
+			StatusCode: 200,
+			Headers: map[string][]string{
+				"Content-Type": {"text/html; charset=utf-8"},
+			},
+			RawData: []byte("<html><body>Contact: support@example.com</body></html>"),
+		}
+		require.False(t, isSecurityTxt(resp))
+	})
+
+	t.Run("missing contact field", func(t *testing.T) {
+		resp := &httpx.Response{
+			StatusCode: 200,
+			Headers: map[string][]string{
+				"Content-Type": {"text/plain"},
+			},
+			RawData: []byte("Expires: 2027-01-01T00:00:00.000Z\n"),
+		}
+		require.False(t, isSecurityTxt(resp))
+	})
+
+	t.Run("wrong status", func(t *testing.T) {
+		resp := &httpx.Response{
+			StatusCode: 404,
+			Headers: map[string][]string{
+				"Content-Type": {"text/plain"},
+			},
+			RawData: []byte("Contact: mailto:security@example.com\n"),
+		}
+		require.False(t, isSecurityTxt(resp))
+	})
+}
+
 func TestRunner_CSVRow(t *testing.T) {
 	// Create a result with fields that would be vulnerable to CSV injection
 	result := Result{

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -286,17 +286,20 @@ func TestRunner_urlWithComma_targets(t *testing.T) {
 	require.ElementsMatch(t, expected, got, "could not expected output")
 }
 
+// TestNormalizeRequestURIs verifies deduplication and trimming of comma-separated URI strings.
 func TestNormalizeRequestURIs(t *testing.T) {
 	got := normalizeRequestURIs("/.well-known/security.txt, /security.txt, /.well-known/security.txt,,")
 	require.Equal(t, []string{"/.well-known/security.txt", "/security.txt"}, got)
 }
 
+// TestAppendCommaSeparatedValue verifies appending values to comma-separated strings.
 func TestAppendCommaSeparatedValue(t *testing.T) {
 	require.Equal(t, "200", appendCommaSeparatedValue("", "200"))
 	require.Equal(t, "200,302", appendCommaSeparatedValue("200", "302"))
 	require.Equal(t, "200", appendCommaSeparatedValue("200", ""))
 }
 
+// TestIsSecurityTxt verifies security.txt detection across valid, invalid, and edge-case responses.
 func TestIsSecurityTxt(t *testing.T) {
 	t.Run("valid security txt", func(t *testing.T) {
 		resp := &httpx.Response{

--- a/runner/types.go
+++ b/runner/types.go
@@ -57,6 +57,7 @@ type Result struct {
 	ResponseBody       string                        `json:"body,omitempty" csv:"-" md:"-" mapstructure:"body"`
 	BodyPreview        string                        `json:"body_preview,omitempty" csv:"body_preview" md:"body_preview" mapstructure:"body_preview"`
 	ContentType        string                        `json:"content_type,omitempty" csv:"content_type" md:"content_type" mapstructure:"content_type"`
+	SecurityTxt        bool                          `json:"security_txt,omitempty" csv:"security_txt" md:"security_txt" mapstructure:"security_txt"`
 	Method             string                        `json:"method,omitempty" csv:"method" md:"method" mapstructure:"method"`
 	Host               string                        `json:"host,omitempty" csv:"host" md:"host" mapstructure:"host"`
 	HostIP             string                        `json:"host_ip,omitempty" csv:"host_ip" md:"host_ip" mapstructure:"host_ip"`


### PR DESCRIPTION
## Summary
- add a native `--security-txt` flag to probe `/.well-known/security.txt` and `/security.txt`
- require HTTP 200 plus a `Contact:` field, and reject non-plain-text responses to reduce soft-404 noise
- expose a `security_txt` boolean in structured output and add focused tests for the helper logic

## Testing
- `go test ./runner -run 'Test(NormalizeRequestURIs|AppendCommaSeparatedValue|IsSecurityTxt|Runner_CSVRow)' -count=1`
- `go test ./...`

Closes #2468


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to detect security.txt files at standard paths (/.well-known/security.txt and /security.txt).
  * Detection results are included in output (JSON output enabled) and a new result field indicates security.txt presence.

* **Tests**
  * Added unit tests covering security.txt detection and request-URI preprocessing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->