### PR TITLE
feat: honor HTTP_PROXY/HTTPS_PROXY env vars when -proxy is unset

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -175,6 +175,8 @@ func New(options *Options) (*HTTPX, error) {
 			return nil, parseErr
 		}
 		transport.Proxy = http.ProxyURL(proxyURL)
+	} else {
+		transport.Proxy = http.ProxyFromEnvironment
 	}
 
 	httpx.client = retryablehttp.NewWithHTTPClient(&http.Client{

--- a/runner/headless.go
+++ b/runner/headless.go
@@ -84,6 +84,14 @@ func NewBrowser(proxy string, useLocal bool, optionalArgs map[string]string) (*B
 		}
 	}
 
+	if proxy == "" {
+		for _, k := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"} {
+			if v := os.Getenv(k); v != "" {
+				proxy = v
+				break
+			}
+		}
+	}
 	if proxy != "" {
 		chromeLauncher = chromeLauncher.Proxy(proxy)
 	}

--- a/runner/options.go
+++ b/runner/options.go
@@ -532,7 +532,7 @@ func ParseOptions() *Options {
 		flagSet.BoolVar(&options.RandomAgent, "random-agent", true, "enable Random User-Agent to use"),
 		flagSet.BoolVar(&options.AutoReferer, "auto-referer", false, "set the Referer header to the current URL"),
 		flagSet.VarP(&options.CustomHeaders, "header", "H", "custom http headers to send with request"),
-		flagSet.StringVarP(&options.Proxy, "proxy", "http-proxy", "", "proxy (http|socks) to use (eg http://127.0.0.1:8080)"),
+		flagSet.StringVarP(&options.Proxy, "proxy", "http-proxy", "", "proxy (http|socks) to use (eg http://127.0.0.1:8080); falls back to HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars"),
 		flagSet.BoolVar(&options.Unsafe, "unsafe", false, "send raw requests skipping golang normalization"),
 		flagSet.BoolVar(&options.Resume, "resume", false, "resume scan using resume.cfg"),
 		flagSet.BoolVarP(&options.FollowRedirects, "follow-redirects", "fr", false, "follow http redirects"),


### PR DESCRIPTION
## Summary
- Fall back to `http.ProxyFromEnvironment` for the HTTP transport when `-proxy` is empty, picking up `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (and lowercase variants).
- Headless launcher does the same lookup manually since chromedp does not read env.
- SOCKS works via `socks5://` URLs in the same vars.

Closes #2492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proxy settings now automatically detect and use HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables as fallback when not explicitly configured.

* **Documentation**
  * Updated proxy flag help text to clarify environment variable fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/httpx/pull/2493)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->