### PR TITLE
fix(runner): return error when -fpt filter fails to initialize

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -434,6 +434,9 @@ func New(options *Options) (*Runner, error) {
 	if options.JSONOutput || options.CSVOutput || len(options.OutputFilterPageType) > 0 {
 		ditClassifier, err := dit.New()
 		if err != nil {
+			if len(options.OutputFilterPageType) > 0 {
+				return nil, fmt.Errorf("could not initialize page classifier for -fpt filter: %w (run 'dit data download' to install the model)", err)
+			}
 			gologger.Warning().Msgf("Could not initialize page classifier: %s", err)
 		}
 		runner.ditClassifier = ditClassifier


### PR DESCRIPTION
## Summary
- When users specify \-fpt\ (filter-page-type) flag, the dit classifier must be successfully initialized
- Previously, if the dit model was missing, httpx would only log a warning and silently fail to apply the filter
- This caused unexpected behavior where error pages would not be filtered as expected

## Changes
- Return a descriptive error when the classifier cannot be initialized for \-fpt\ usage
- Include guidance for users to run \dit data download\ to install the required model

## Proof

**Before (silent failure):**
\\\
httpx -u jsdk.baidu.com -fpt error
https://jsdk.baidu.com  # Error page NOT filtered
\\\

**After (clear error):**
\\\
httpx -u jsdk.baidu.com -fpt error
FATAL: could not initialize page classifier for -fpt filter: dit: model.json not found (run 'dit data download' to install the model)
\\\

## Checklist
- [x] PR created against the correct branch (main)
- [x] Code follows project conventions
- [x] Fix is minimal and focused

/claim #2495