### PR TITLE
Populate CPE version when ASQ product names differ from wappalyzer

### DIFF
--- a/runner/cpe.go
+++ b/runner/cpe.go
@@ -160,6 +160,88 @@ func normalizeProductName(name string) string {
 	return b.String()
 }
 
+// cpeProductSuffixes are common awesome-search-queries product suffixes stripped
+// to derive shorter lookup aliases (e.g. liferay_portal -> liferay).
+var cpeProductSuffixes = []string{
+	"_server",
+	"_portal",
+	"_software",
+	"_platform",
+	"_suite",
+	"_service",
+	"_manager",
+	"_panel",
+	"_cms",
+	"_firmware",
+	"_gateway",
+	"_proxy",
+	"_system",
+	"_application",
+	"_framework",
+	"_tower",
+	"_policy_manager",
+}
+
+// productLookupKeys returns normalized lookup keys for joining a CPE product
+// name to wappalyzer technology names. Keys are ordered most-specific first;
+// the first key with a version match wins.
+func productLookupKeys(product string) []string {
+	product = strings.TrimSpace(product)
+	if product == "" {
+		return nil
+	}
+
+	// Compound awesome-search-queries names list multiple products; the first is
+	// the primary identifier for version lookup purposes.
+	if idx := strings.Index(product, ","); idx >= 0 {
+		product = strings.TrimSpace(product[:idx])
+	}
+
+	seen := make(map[string]struct{})
+	keys := make([]string, 0, 4)
+	addKey := func(raw string) {
+		key := normalizeProductName(raw)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+
+	addKey(product)
+
+	lower := strings.ToLower(product)
+	for _, suffix := range cpeProductSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			addKey(strings.TrimSuffix(lower, suffix))
+		}
+	}
+
+	if strings.Contains(lower, "_") {
+		parts := strings.Split(lower, "_")
+		addKey(parts[0])
+		for i := 2; i <= len(parts); i++ {
+			addKey(strings.Join(parts[:i], "_"))
+		}
+	}
+
+	return keys
+}
+
+// lookupTechVersion finds a wappalyzer version for a CPE product using exact
+// and alias keys derived from awesome-search-queries naming conventions.
+func lookupTechVersion(product string, versions map[string]string) (string, bool) {
+	for _, key := range productLookupKeys(product) {
+		if version, ok := versions[key]; ok {
+			return version, true
+		}
+	}
+	return "", false
+}
+
 // buildTechVersionMap maps normalized technology name -> version, parsing
 // wappalyzer's "Name:version" entries (FormatAppVersion convention). Entries
 // without a version are skipped. A product reported with conflicting versions
@@ -203,7 +285,7 @@ func EnrichCPEVersions(matches []CPEInfo, technologies []string) []CPEInfo {
 	enriched := make([]CPEInfo, len(matches))
 	for i, match := range matches {
 		enriched[i] = match
-		if version, ok := versions[normalizeProductName(match.Product)]; ok {
+		if version, ok := lookupTechVersion(match.Product, versions); ok {
 			enriched[i].CPE = setCPEVersion(match.CPE, version)
 		}
 	}

--- a/runner/cpe.go
+++ b/runner/cpe.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	awesomesearchqueries "github.com/projectdiscovery/awesome-search-queries"
@@ -214,7 +215,11 @@ func productLookupKeys(product string) []string {
 	addKey(product)
 
 	lower := strings.ToLower(product)
-	for _, suffix := range cpeProductSuffixes {
+	suffixes := slices.Clone(cpeProductSuffixes)
+	slices.SortFunc(suffixes, func(a, b string) int {
+		return len(b) - len(a)
+	})
+	for _, suffix := range suffixes {
 		if strings.HasSuffix(lower, suffix) {
 			addKey(strings.TrimSuffix(lower, suffix))
 		}

--- a/runner/cpe_test.go
+++ b/runner/cpe_test.go
@@ -183,6 +183,11 @@ func TestProductLookupKeys(t *testing.T) {
 			want: []string{"tableauserver", "tableau"},
 		},
 		{
+			name: "longest suffix takes priority",
+			in:   "ansible_policy_manager",
+			want: []string{"ansiblepolicymanager", "ansible", "ansiblepolicy"},
+		},
+		{
 			name: "compound name uses primary product",
 			in:   "digital_experience_platform,liferay_portal",
 			want: []string{"digitalexperienceplatform", "digitalexperience", "digital"},
@@ -226,6 +231,7 @@ func TestLookupTechVersion(t *testing.T) {
 		"Confluence:8.5.1",
 		"Tableau:2023.1",
 		"Apache HTTP Server:2.4.7",
+		"Ansible:2.14.0",
 	})
 
 	tests := []struct {
@@ -237,6 +243,7 @@ func TestLookupTechVersion(t *testing.T) {
 		{"liferay", "7.3.5", true},
 		{"confluence_server", "8.5.1", true},
 		{"tableau_server", "2023.1", true},
+		{"ansible_policy_manager", "2.14.0", true},
 		{"Apache HTTP Server", "2.4.7", true},
 		{"phpcollab", "", false},
 		{"unknown_product", "", false},
@@ -304,6 +311,14 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 			cpe:          "cpe:2.3:a:redhat:ansible_tower:*:*:*:*:*:*:*:*",
 			technologies: []string{"Ansible:2.14.0"},
 			wantCPE:      "cpe:2.3:a:redhat:ansible_tower:2.14.0:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "ansible policy manager prefers ansible alias",
+			product:      "ansible_policy_manager",
+			vendor:       "redhat",
+			cpe:          "cpe:2.3:a:redhat:ansible_policy_manager:*:*:*:*:*:*:*:*",
+			technologies: []string{"Ansible:2.14.0"},
+			wantCPE:      "cpe:2.3:a:redhat:ansible_policy_manager:2.14.0:*:*:*:*:*:*:*",
 		},
 		{
 			name:         "conflicting tech versions leave cpe unchanged",

--- a/runner/cpe_test.go
+++ b/runner/cpe_test.go
@@ -159,6 +159,172 @@ func TestBuildTechVersionMap(t *testing.T) {
 	}
 }
 
+func TestProductLookupKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "liferay portal strips suffix",
+			in:   "liferay_portal",
+			want: []string{"liferayportal", "liferay"},
+		},
+		{
+			name: "confluence server strips suffix",
+			in:   "confluence_server",
+			want: []string{"confluenceserver", "confluence"},
+		},
+		{
+			name: "tableau server strips suffix",
+			in:   "tableau_server",
+			want: []string{"tableauserver", "tableau"},
+		},
+		{
+			name: "compound name uses primary product",
+			in:   "digital_experience_platform,liferay_portal",
+			want: []string{"digitalexperienceplatform", "digitalexperience", "digital"},
+		},
+		{
+			name: "display name unchanged",
+			in:   "Apache HTTP Server",
+			want: []string{"apachehttpserver"},
+		},
+		{
+			name: "simple product",
+			in:   "next.js",
+			want: []string{"nextjs"},
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := productLookupKeys(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("productLookupKeys(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("productLookupKeys(%q)[%d] = %q, want %q (full: %v)", tt.in, i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestLookupTechVersion(t *testing.T) {
+	t.Parallel()
+
+	versions := buildTechVersionMap([]string{
+		"Liferay:7.3.5",
+		"Confluence:8.5.1",
+		"Tableau:2023.1",
+		"Apache HTTP Server:2.4.7",
+	})
+
+	tests := []struct {
+		product   string
+		want      string
+		wantFound bool
+	}{
+		{"liferay_portal", "7.3.5", true},
+		{"liferay", "7.3.5", true},
+		{"confluence_server", "8.5.1", true},
+		{"tableau_server", "2023.1", true},
+		{"Apache HTTP Server", "2.4.7", true},
+		{"phpcollab", "", false},
+		{"unknown_product", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.product, func(t *testing.T) {
+			got, ok := lookupTechVersion(tt.product, versions)
+			if ok != tt.wantFound {
+				t.Fatalf("lookupTechVersion(%q) found = %v, want %v", tt.product, ok, tt.wantFound)
+			}
+			if got != tt.want {
+				t.Fatalf("lookupTechVersion(%q) = %q, want %q", tt.product, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnrichCPEVersionsIssue2536(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		product      string
+		vendor       string
+		cpe          string
+		technologies []string
+		wantCPE      string
+	}{
+		{
+			name:         "liferay portal product name from awesome-search-queries",
+			product:      "liferay_portal",
+			vendor:       "liferay",
+			cpe:          "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+			technologies: []string{"Liferay:7.3.5"},
+			wantCPE:      "cpe:2.3:a:liferay:liferay_portal:7.3.5:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "confluence server product name",
+			product:      "confluence_server",
+			vendor:       "atlassian",
+			cpe:          "cpe:2.3:a:atlassian:confluence_server:*:*:*:*:*:*:*:*",
+			technologies: []string{"Confluence:8.5.1"},
+			wantCPE:      "cpe:2.3:a:atlassian:confluence_server:8.5.1:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "tableau server product name",
+			product:      "tableau_server",
+			vendor:       "tableau",
+			cpe:          "cpe:2.3:a:tableau:tableau_server:*:*:*:*:*:*:*:*",
+			technologies: []string{"Tableau:2023.1"},
+			wantCPE:      "cpe:2.3:a:tableau:tableau_server:2023.1:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "no false match on unrelated substring",
+			product:      "phpcollab",
+			vendor:       "phpcollab",
+			cpe:          "cpe:2.3:a:phpcollab:phpcollab:*:*:*:*:*:*:*:*",
+			technologies: []string{"PHP:8.1.0"},
+			wantCPE:      "cpe:2.3:a:phpcollab:phpcollab:*:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "ansible tower strips suffix",
+			product:      "ansible_tower",
+			vendor:       "redhat",
+			cpe:          "cpe:2.3:a:redhat:ansible_tower:*:*:*:*:*:*:*:*",
+			technologies: []string{"Ansible:2.14.0"},
+			wantCPE:      "cpe:2.3:a:redhat:ansible_tower:2.14.0:*:*:*:*:*:*:*",
+		},
+		{
+			name:         "conflicting tech versions leave cpe unchanged",
+			product:      "liferay_portal",
+			vendor:       "liferay",
+			cpe:          "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+			technologies: []string{"Liferay:7.3.5", "Liferay:7.4.0"},
+			wantCPE:      "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := []CPEInfo{{Product: tt.product, Vendor: tt.vendor, CPE: tt.cpe}}
+			got := EnrichCPEVersions(matches, tt.technologies)
+			if got[0].CPE != tt.wantCPE {
+				t.Fatalf("CPE = %q, want %q", got[0].CPE, tt.wantCPE)
+			}
+		})
+	}
+}
+
 func TestBuildTechVersionMapConflict(t *testing.T) {
 	// the same product reported with two versions must be dropped, not resolved
 	// by random map iteration order.
@@ -233,8 +399,9 @@ func TestEnrichCPEVersionsWithRealWappalyzer(t *testing.T) {
 		t.Fatalf("expected wappalyzer to emit \"Liferay:7.3.5\", got %v", technologies)
 	}
 
+	// awesome-search-queries uses snake_case product names; issue #2536.
 	matches := []CPEInfo{
-		{Product: "Liferay", Vendor: "liferay", CPE: "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*"},
+		{Product: "liferay_portal", Vendor: "liferay", CPE: "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*"},
 	}
 	got := EnrichCPEVersions(matches, technologies)
 	if got[0].CPE != "cpe:2.3:a:liferay:liferay_portal:7.3.5:*:*:*:*:*:*:*" {


### PR DESCRIPTION
Closes #2536

CPE version enrichment failed when awesome-search-queries product names (e.g. `liferay_portal`) did not normalize to the same key as wappalyzer tech names (`Liferay`).

Adds alias lookup: strip common suffixes (`_server`, `_portal`, …), underscore segments, and compound product names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPE version enrichment to better recognize products when naming varies (aliases, common suffixes, and alternate formatting).
  * Fixed enrichment for snake_case product names to correctly inject the expected CPE version.
  * Reduced incorrect technology/version matches, keeping CPE versions unchanged when versions conflict.
* **Tests**
  * Added unit and regression coverage for alias-aware lookup behavior and the affected issue case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->