### PR TITLE
group external dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,13 @@ updates:
     labels:
       - "Type: Maintenance"
     groups:
-      modules:
+      # Internal PD libraries — usually safe to review as a batch
+      projectdiscovery:
         patterns: ["github.com/projectdiscovery/*"]
+      # Everything else (faker, dit, etc.) — separate from PD bumps
+      external:
+        patterns: ["*"]
+        exclude-patterns: ["github.com/projectdiscovery/*"]
 
 #  # Maintain dependencies for GitHub Actions
 #  - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,10 @@ updates:
     labels:
       - "Type: Maintenance"
     groups:
-      # Internal PD libraries — usually safe to review as a batch
+      # Internal PD libraries, usually safe to review as a batch
       projectdiscovery:
         patterns: ["github.com/projectdiscovery/*"]
-      # Everything else (faker, dit, etc.) — separate from PD bumps
+      # Other packages, separate from PD bumps
       external:
         patterns: ["*"]
         exclude-patterns: ["github.com/projectdiscovery/*"]


### PR DESCRIPTION
Split gomod Dependabot into two groups: projectdiscovery for github.com/projectdiscovery/* and external for everything else. That keeps PD bumps reviewable as a batch without leaving non-PD modules (go-faker, dit, etc.) as solo PRs.

Open solos #2540 and #2541 will not fold automatically; close them after the next Dependabot run or manually.