### PR TITLE
Pin workflow actions and fix the codeql-action advisory exposure

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.DEPENDABOT_PAT }}
 
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2.6.6
         with:
           github-token: ${{ secrets.DEPENDABOT_PAT }}
           target: all

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,9 @@ on:
       - '**.mod'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,9 +13,9 @@ jobs:
     if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: projectdiscovery/actions/setup/go@v1
-      - uses: projectdiscovery/actions/golangci-lint/v2@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: projectdiscovery/actions/setup/go@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
+      - uses: projectdiscovery/actions/golangci-lint/v2@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
 
   build:
     name: Test Builds
@@ -25,8 +25,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: projectdiscovery/actions/setup/go@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: projectdiscovery/actions/setup/go@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
       - run: go build .
         working-directory: cmd/httpx/
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,12 +29,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/compatibility-checks.yaml
+++ b/.github/workflows/compatibility-checks.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: projectdiscovery/actions/setup/go/compat-checks@master
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: projectdiscovery/actions/setup/go/compat-checks@5ad9460589b729fcc7210fd809063a848ea407db # master
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/dep-auto-merge.yml
+++ b/.github/workflows/dep-auto-merge.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           token: ${{ secrets.DEPENDABOT_PAT }}
 
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2.6.6
         with:
           github-token: ${{ secrets.DEPENDABOT_PAT }}
           target: all

--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Get Github tag
         id: meta
@@ -20,19 +20,19 @@ jobs:
           curl --silent "https://api.github.com/repos/projectdiscovery/httpx/releases/latest" | jq -r .tag_name | xargs -I {} echo TAG={} >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2 
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm

--- a/.github/workflows/dockerhub-push.yml
+++ b/.github/workflows/dockerhub-push.yml
@@ -7,6 +7,9 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: projectdiscovery/actions/setup/go@v1
+      - uses: projectdiscovery/actions/setup/go@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
 
       - name: Functional Tests
         run: |

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -7,6 +7,9 @@ on:
       - '**.mod'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   functional:
     name: Functional Test

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: projectdiscovery/actions/setup/go@v1
+      - uses: projectdiscovery/actions/setup/go@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
 
       - name: "Create release on GitHub"
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           args: "release --clean"
           version: latest

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -6,6 +6,10 @@ on:
       - '*'
   workflow_dispatch:
 
+permissions:
+  # goreleaser creates the release and uploads the binaries.
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: "Check out code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: projectdiscovery/actions/setup/go@v1
+      - uses: projectdiscovery/actions/setup/go@4ff2f2094e67bb1819a069aa130a49463ecaa3f3 # v1.29.4
 
       - name: release test
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           args: "release --clean --snapshot"
           version: latest

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -7,6 +7,9 @@ on:
       - '**.mod'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release-test:
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 90
           days-before-close: 7


### PR DESCRIPTION
## Proposed changes

Three commits, nothing about how the workflows behave changes except one security bump.

- **Move codeql-action off the advisory-affected v2 line.** The v2 releases from 2.26.11 on sit in the range of [GHSA-vqf5-2xx6-9wfm](https://github.com/advisories/GHSA-vqf5-2xx6-9wfm), CodeQL debug artifacts could contain the GitHub PAT, and no fixed v2 release exists, the fix shipped in 3.28.3. The v2 line is also deprecated. The three references move to the current release, pinned by SHA.
- **Pin every workflow action to a full commit SHA.** The release path runs goreleaser with a token that can create releases, and the docker workflow logs into Docker Hub with the registry credentials. A version tag is a movable pointer, whoever controls an action repository can point it at different code after review, which is exactly what the tj-actions/changed-files incident (CVE-2025-30066) did to leak CI secrets. A SHA cannot be retargeted. Each pin keeps the version as a trailing comment for cross-checking against the action's releases page, versions stay exactly where they were, and dependabot keeps bumping SHA pins the same way it bumps tags today. This also settles the codeql refs resolving ambiguously as both a tag and a branch. The `projectdiscovery/actions` pins are included for consistency, happy to drop those hunks if you prefer trusting your own org namespace.
- **Declare token permissions.** Only the release workflow writes through the GitHub token (goreleaser creating the release), it keeps `contents: write`. The test and docker workflows drop to read only, the Docker Hub push authenticates with its own registry credentials.

One heads-up: if the org restricts allowed actions with tag patterns like `owner/action@v2`, those patterns stop matching SHA refs and workflows fail at startup, the fix is `owner/action@*` in that setting. Nothing to do if no such restriction is configured.

### Proof

Every SHA resolves to the exact tag named in its comment, verifiable on each action's releases page. All workflow files parse and the changes are ref-format only, except the codeql bump described above.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/httpx/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works *(not applicable, workflow-only change)*
- [ ] I have added necessary documentation (if appropriate) *(not applicable)*

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.