### PR TITLE
feat: add -kb to make page type classification opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ PROBES:
    -server, -web-server                   display server name
    -td, -tech-detect                      display technology in use based on wappalyzer dataset
    -cff, -custom-fingerprint-file string  path to a custom fingerprint file for technology detection
+   -kb, -knowledge-base                   enable knowledge base classification
    -method                                display http request method
    -ws, -websocket                        display server using websocket
    -ip                                    display host ip

--- a/runner/options.go
+++ b/runner/options.go
@@ -204,6 +204,9 @@ type Options struct {
 	// Deprecated: use OutputFilterPageType with "error" instead.
 	OutputFilterErrorPage bool
 	OutputFilterPageType      goflags.StringSlice
+	// KnowledgeBase enables knowledge base classification using dit. It is
+	// implied by OutputFilterPageType/OutputFilterErrorPage, which need it.
+	KnowledgeBase             bool
 	FilterOutDuplicates       bool
 	OutputFilterContentLength string
 	InputRawRequest           string
@@ -412,6 +415,7 @@ func ParseOptions() *Options {
 		flagSet.StringVarP(&options.CustomFingerprintFile, "custom-fingerprint-file", "cff", "", "path to a custom fingerprint file for technology detection"),
 		flagSet.BoolVar(&options.CPEDetect, "cpe", false, "display CPE (Common Platform Enumeration) with product version based on awesome-search-queries"),
 		flagSet.BoolVarP(&options.WordPress, "wordpress", "wp", false, "display WordPress plugins and themes"),
+		flagSet.BoolVarP(&options.KnowledgeBase, "knowledge-base", "kb", false, "enable knowledge base classification"),
 		flagSet.BoolVar(&options.OutputMethod, "method", false, "display http request method"),
 		flagSet.BoolVarP(&options.OutputWebSocket, "websocket", "ws", false, "display server using websocket"),
 		flagSet.BoolVar(&options.OutputIP, "ip", false, "display host ip"),
@@ -720,6 +724,19 @@ func (options *Options) HasMatcherOrFilter() bool {
 		options.OutputFilterResponseTime != ""
 }
 
+// hasPageTypeFilter reports whether a filter that depends on the page type
+// classification is in use.
+func (options *Options) hasPageTypeFilter() bool {
+	return len(options.OutputFilterPageType) > 0 || options.OutputFilterErrorPage
+}
+
+// classificationEnabled reports whether the knowledge base classifier should be
+// loaded. It is opt-in via -kb, and implied by the page type filters that
+// cannot work without it.
+func (options *Options) classificationEnabled() bool {
+	return options.KnowledgeBase || options.hasPageTypeFilter()
+}
+
 func (options *Options) ValidateOptions() error {
 	if options.InputFile != "" && !fileutilz.FileNameIsGlob(options.InputFile) && !fileutil.FileExists(options.InputFile) {
 		return fmt.Errorf("file '%s' does not exist", options.InputFile)
@@ -916,6 +933,10 @@ func (options *Options) configureOutput() {
 	if options.OutputFilterErrorPage && len(options.OutputFilterPageType) == 0 {
 		gologger.Info().Msg("-fep is deprecated, use -fpt error instead")
 		options.OutputFilterPageType = goflags.StringSlice{"error"}
+	}
+	// page type filters cannot work without the classifier
+	if options.hasPageTypeFilter() {
+		options.KnowledgeBase = true
 	}
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -431,10 +431,15 @@ func New(options *Options) (*Runner, error) {
 	}
 
 	runner.simHashes = gcache.New[uint64, []string](1000).ARC().Build()
-	if options.JSONOutput || options.CSVOutput || len(options.OutputFilterPageType) > 0 {
+	if options.classificationEnabled() {
 		ditClassifier, err := dit.New()
 		if err != nil {
-			gologger.Warning().Msgf("Could not initialize page classifier: %s", err)
+			// without a classifier the page type filters silently pass
+			// everything through, so a failure is fatal when one is in use
+			if options.hasPageTypeFilter() {
+				return nil, errors.Wrap(err, "could not initialize page classifier")
+			}
+			gologger.Error().Msgf("Could not initialize page classifier: %s", err)
 		}
 		runner.ditClassifier = ditClassifier
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -434,12 +434,7 @@ func New(options *Options) (*Runner, error) {
 	if options.classificationEnabled() {
 		ditClassifier, err := dit.New()
 		if err != nil {
-			// without a classifier the page type filters silently pass
-			// everything through, so a failure is fatal when one is in use
-			if options.hasPageTypeFilter() {
-				return nil, errors.Wrap(err, "could not initialize page classifier")
-			}
-			gologger.Error().Msgf("Could not initialize page classifier: %s", err)
+			return nil, errors.Wrap(err, "could not initialize page classifier")
 		}
 		runner.ditClassifier = ditClassifier
 	}


### PR DESCRIPTION
Closes #2543

`-json`/`-csv` initialized the dit classifier, downloading a ~92MB model with no way to opt out. Classification is now opt-in via `-kb`, implied by `-fpt`/`-fep`.

Supersedes #2544 (thanks @jatinder14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added knowledge base classification through the `-knowledge-base` and `-kb` command-line options.
  - Knowledge base classification is automatically enabled when page-type or legacy error-page filters are used.

- **Bug Fixes**
  - Improved classifier initialization across supported classification scenarios.
  - Classification setup failures are now reported clearly instead of being ignored.

- **Documentation**
  - Updated usage documentation with the new knowledge base option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->