### PR TITLE
fix(cpe): substring fallback for vendor-prefix mismatches (#2550)

### DIFF
--- a/runner/cpe.go
+++ b/runner/cpe.go
@@ -236,14 +236,42 @@ func productLookupKeys(product string) []string {
 	return keys
 }
 
+// minSubstringMatchLen guards the substring fallback in lookupTechVersion so
+// short, generic keys (e.g. "web", "cms") can't cause false-positive matches
+// against an unrelated technology.
+const minSubstringMatchLen = 5
+
 // lookupTechVersion finds a wappalyzer version for a CPE product using exact
 // and alias keys derived from awesome-search-queries naming conventions.
+//
+// If no exact key matches, it falls back to substring containment between the
+// CPE product's lookup keys and each detected technology's normalized name.
+// This catches the common case where wappalyzer's display name carries a
+// vendor prefix the CPE dictionary's product name omits (e.g. "Apache Tomcat"
+// vs. CPE product "tomcat"), or the reverse, where the CPE dictionary's name
+// is more specific (e.g. wappalyzer's "D3" vs. CPE product "d3.js").
 func lookupTechVersion(product string, versions map[string]string) (string, bool) {
-	for _, key := range productLookupKeys(product) {
+	keys := productLookupKeys(product)
+	for _, key := range keys {
 		if version, ok := versions[key]; ok {
 			return version, true
 		}
 	}
+
+	for _, key := range keys {
+		if len(key) < minSubstringMatchLen {
+			continue
+		}
+		for techName, version := range versions {
+			if len(techName) < minSubstringMatchLen {
+				continue
+			}
+			if strings.Contains(techName, key) || strings.Contains(key, techName) {
+				return version, true
+			}
+		}
+	}
+
 	return "", false
 }
 

--- a/runner/cpe.go
+++ b/runner/cpe.go
@@ -183,19 +183,30 @@ var cpeProductSuffixes = []string{
 	"_policy_manager",
 }
 
+// cpeProductAliases maps known dataset naming differences that cannot be
+// resolved safely by the generic token fallback.
+var cpeProductAliases = map[string][]string{
+	"d3.js":  {"d3"},
+	"matomo": {"matomoanalytics"},
+}
+
+// primaryProductName returns the primary identifier from compound
+// awesome-search-queries product names.
+func primaryProductName(product string) string {
+	product = strings.TrimSpace(product)
+	if idx := strings.Index(product, ","); idx >= 0 {
+		product = strings.TrimSpace(product[:idx])
+	}
+	return product
+}
+
 // productLookupKeys returns normalized lookup keys for joining a CPE product
 // name to wappalyzer technology names. Keys are ordered most-specific first;
 // the first key with a version match wins.
 func productLookupKeys(product string) []string {
-	product = strings.TrimSpace(product)
+	product = primaryProductName(product)
 	if product == "" {
 		return nil
-	}
-
-	// Compound awesome-search-queries names list multiple products; the first is
-	// the primary identifier for version lookup purposes.
-	if idx := strings.Index(product, ","); idx >= 0 {
-		product = strings.TrimSpace(product[:idx])
 	}
 
 	seen := make(map[string]struct{})
@@ -215,6 +226,10 @@ func productLookupKeys(product string) []string {
 	addKey(product)
 
 	lower := strings.ToLower(product)
+	for _, alias := range cpeProductAliases[lower] {
+		addKey(alias)
+	}
+
 	suffixes := slices.Clone(cpeProductSuffixes)
 	slices.SortFunc(suffixes, func(a, b string) int {
 		return len(b) - len(a)
@@ -236,25 +251,56 @@ func productLookupKeys(product string) []string {
 	return keys
 }
 
-// minTokenMatchLen guards the token fallback in lookupTechVersion so short
-// words ("web", "cms") can't cause spurious matches between unrelated
-// technologies.
+// fallbackProductLookupKeys returns only aliases that preserve the complete
+// product identity. Unlike productLookupKeys, it does not add underscore
+// prefixes such as "tomcat" for "tomcat_jk_connector", which are useful for
+// exact technology names but too broad after vendor-prefix removal.
+func fallbackProductLookupKeys(product string) []string {
+	product = primaryProductName(product)
+	if product == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	keys := make([]string, 0, 3)
+	addKey := func(raw string) {
+		key := normalizeProductName(raw)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+
+	addKey(product)
+	lower := strings.ToLower(product)
+	for _, alias := range cpeProductAliases[lower] {
+		addKey(alias)
+	}
+	for _, suffix := range cpeProductSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			addKey(strings.TrimSuffix(lower, suffix))
+		}
+	}
+	return keys
+}
+
+// minTokenMatchLen guards vendor matching so short words cannot establish
+// identity between unrelated technologies.
 const minTokenMatchLen = 5
 
-// genericProductTokens are words too common across unrelated products to be
-// used as the sole basis for a fallback match (e.g. matching on "framework"
-// alone could pair a detected "Fluid Framework" version with a completely
-// different CPE product that also happens to be a framework). This overlaps
-// deliberately with cpeProductSuffixes, since those are already known to be
-// non-discriminative.
-var genericProductTokens = map[string]struct{}{
+// genericMatchTokens are too common to establish vendor identity.
+var genericMatchTokens = map[string]struct{}{
 	"server": {}, "portal": {}, "software": {}, "platform": {}, "suite": {},
 	"service": {}, "services": {}, "manager": {}, "panel": {}, "cms": {},
 	"firmware": {}, "gateway": {}, "proxy": {}, "system": {}, "application": {},
 	"framework": {}, "tower": {}, "commerce": {}, "ecommerce": {}, "network": {},
 	"internet": {}, "captcha": {}, "cloud": {}, "web": {}, "app": {},
 	"plugin": {}, "widget": {}, "tool": {}, "tools": {}, "analytics": {},
-	"tag": {}, "api": {},
+	"tag": {}, "api": {}, "project": {}, "builder": {},
 }
 
 // technologyTokens splits a name into lowercase alphanumeric words, breaking
@@ -296,7 +342,7 @@ func strongTokens(name string) []string {
 		if len(t) < minTokenMatchLen {
 			continue
 		}
-		if _, generic := genericProductTokens[t]; generic {
+		if _, generic := genericMatchTokens[t]; generic {
 			continue
 		}
 		filtered = append(filtered, t)
@@ -304,15 +350,15 @@ func strongTokens(name string) []string {
 	return filtered
 }
 
-// buildTechVersionTokenIndex maps each strong word of every detected
-// technology's name to its version, for the fallback in lookupTechVersion. A
-// token shared by technologies reported with different versions is dropped as
-// ambiguous rather than resolved by map iteration order, which is random -
-// the same conflict-drop rule buildTechVersionMap already applies to exact
-// names.
-func buildTechVersionTokenIndex(technologies []string) map[string]string {
-	tokenVersions := make(map[string]string)
-	conflicting := make(map[string]struct{})
+type technologyVersion struct {
+	version string
+	tokens  []string
+}
+
+// buildTechnologyVersions parses versioned technology names into candidates
+// used by the conservative product/vendor fallback.
+func buildTechnologyVersions(technologies []string) []technologyVersion {
+	candidates := make([]technologyVersion, 0, len(technologies))
 	for _, tech := range technologies {
 		parts := strings.SplitN(tech, ":", 2)
 		if len(parts) != 2 {
@@ -322,32 +368,24 @@ func buildTechVersionTokenIndex(technologies []string) map[string]string {
 		if version == "" {
 			continue
 		}
-		for _, token := range strongTokens(parts[0]) {
-			if _, ok := conflicting[token]; ok {
-				continue
-			}
-			if existing, ok := tokenVersions[token]; ok && existing != version {
-				delete(tokenVersions, token)
-				conflicting[token] = struct{}{}
-				continue
-			}
-			tokenVersions[token] = version
+		tokens := technologyTokens(parts[0])
+		if len(tokens) == 0 {
+			continue
 		}
+		candidates = append(candidates, technologyVersion{version: version, tokens: tokens})
 	}
-	return tokenVersions
+	return candidates
 }
 
 // lookupTechVersion finds a wappalyzer version for a CPE product using exact
 // and alias keys derived from awesome-search-queries naming conventions.
 //
-// If no exact key matches, it falls back to tokenVersions: a whole-word index
-// of every detected technology's name (see buildTechVersionTokenIndex). This
-// catches the common case where wappalyzer's display name carries a vendor
-// prefix the CPE dictionary's product name omits (e.g. "Apache Tomcat" vs.
-// CPE product "tomcat"), while whole-word matching - rather than raw
-// substring containment - keeps lexically similar but unrelated products
-// (e.g. "React" vs. "Preact") from being confused for one another.
-func lookupTechVersion(product string, versions, tokenVersions map[string]string) (string, bool) {
+// If no exact key matches, the fallback removes CPE vendor words from each
+// detected technology and requires the remaining name to equal a product
+// lookup key. This catches "Apache Tomcat" versus vendor "apache", product
+// "tomcat" without matching unrelated products on broad shared words. Every
+// candidate must agree on the version.
+func lookupTechVersion(product, vendor string, versions map[string]string, candidates []technologyVersion) (string, bool) {
 	keys := productLookupKeys(product)
 	for _, key := range keys {
 		if version, ok := versions[key]; ok {
@@ -355,13 +393,47 @@ func lookupTechVersion(product string, versions, tokenVersions map[string]string
 		}
 	}
 
-	for _, token := range strongTokens(product) {
-		if version, ok := tokenVersions[token]; ok {
-			return version, true
+	fallbackKeys := fallbackProductLookupKeys(product)
+	productKeys := make(map[string]struct{}, len(fallbackKeys))
+	for _, key := range fallbackKeys {
+		productKeys[key] = struct{}{}
+	}
+	vendorTokens := make(map[string]struct{})
+	for _, token := range strongTokens(vendor) {
+		vendorTokens[token] = struct{}{}
+	}
+	if len(productKeys) == 0 || len(vendorTokens) == 0 {
+		return "", false
+	}
+
+	var version string
+	for _, candidate := range candidates {
+		var residual strings.Builder
+		vendorMatch := false
+		for _, token := range candidate.tokens {
+			if _, ok := vendorTokens[token]; ok {
+				vendorMatch = true
+				continue
+			}
+			residual.WriteString(token)
+		}
+		if !vendorMatch {
+			continue
+		}
+		if _, ok := productKeys[residual.String()]; !ok {
+			continue
+		}
+
+		if version == "" {
+			version = candidate.version
+			continue
+		}
+		if version != candidate.version {
+			return "", false
 		}
 	}
 
-	return "", false
+	return version, version != ""
 }
 
 // buildTechVersionMap maps normalized technology name -> version, parsing
@@ -403,12 +475,12 @@ func EnrichCPEVersions(matches []CPEInfo, technologies []string) []CPEInfo {
 		return append([]CPEInfo(nil), matches...)
 	}
 	versions := buildTechVersionMap(technologies)
-	tokenVersions := buildTechVersionTokenIndex(technologies)
+	candidates := buildTechnologyVersions(technologies)
 
 	enriched := make([]CPEInfo, len(matches))
 	for i, match := range matches {
 		enriched[i] = match
-		if version, ok := lookupTechVersion(match.Product, versions, tokenVersions); ok {
+		if version, ok := lookupTechVersion(match.Product, match.Vendor, versions, candidates); ok {
 			enriched[i].CPE = setCPEVersion(match.CPE, version)
 		}
 	}

--- a/runner/cpe.go
+++ b/runner/cpe.go
@@ -236,21 +236,118 @@ func productLookupKeys(product string) []string {
 	return keys
 }
 
-// minSubstringMatchLen guards the substring fallback in lookupTechVersion so
-// short, generic keys (e.g. "web", "cms") can't cause false-positive matches
-// against an unrelated technology.
-const minSubstringMatchLen = 5
+// minTokenMatchLen guards the token fallback in lookupTechVersion so short
+// words ("web", "cms") can't cause spurious matches between unrelated
+// technologies.
+const minTokenMatchLen = 5
+
+// genericProductTokens are words too common across unrelated products to be
+// used as the sole basis for a fallback match (e.g. matching on "framework"
+// alone could pair a detected "Fluid Framework" version with a completely
+// different CPE product that also happens to be a framework). This overlaps
+// deliberately with cpeProductSuffixes, since those are already known to be
+// non-discriminative.
+var genericProductTokens = map[string]struct{}{
+	"server": {}, "portal": {}, "software": {}, "platform": {}, "suite": {},
+	"service": {}, "services": {}, "manager": {}, "panel": {}, "cms": {},
+	"firmware": {}, "gateway": {}, "proxy": {}, "system": {}, "application": {},
+	"framework": {}, "tower": {}, "commerce": {}, "ecommerce": {}, "network": {},
+	"internet": {}, "captcha": {}, "cloud": {}, "web": {}, "app": {},
+	"plugin": {}, "widget": {}, "tool": {}, "tools": {}, "analytics": {},
+	"tag": {}, "api": {},
+}
+
+// technologyTokens splits a name into lowercase alphanumeric words, breaking
+// on every non-alphanumeric rune. Unlike normalizeProductName, words are kept
+// separate rather than concatenated: "React" -> ["react"], "Apache Tomcat" ->
+// ["apache", "tomcat"], "d3.js" -> ["d3", "js"]. This preserves word
+// boundaries that a plain substring match would ignore - "react" is a
+// character-for-character substring of "preact", but the two never share a
+// token.
+func technologyTokens(name string) []string {
+	var tokens []string
+	var b strings.Builder
+	flush := func() {
+		if b.Len() > 0 {
+			tokens = append(tokens, b.String())
+			b.Reset()
+		}
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		default:
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+// strongTokens returns technologyTokens filtered to words long and specific
+// enough to be trusted for fallback matching.
+func strongTokens(name string) []string {
+	tokens := technologyTokens(name)
+	filtered := tokens[:0]
+	for _, t := range tokens {
+		if len(t) < minTokenMatchLen {
+			continue
+		}
+		if _, generic := genericProductTokens[t]; generic {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
+}
+
+// buildTechVersionTokenIndex maps each strong word of every detected
+// technology's name to its version, for the fallback in lookupTechVersion. A
+// token shared by technologies reported with different versions is dropped as
+// ambiguous rather than resolved by map iteration order, which is random -
+// the same conflict-drop rule buildTechVersionMap already applies to exact
+// names.
+func buildTechVersionTokenIndex(technologies []string) map[string]string {
+	tokenVersions := make(map[string]string)
+	conflicting := make(map[string]struct{})
+	for _, tech := range technologies {
+		parts := strings.SplitN(tech, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		version := strings.TrimSpace(parts[1])
+		if version == "" {
+			continue
+		}
+		for _, token := range strongTokens(parts[0]) {
+			if _, ok := conflicting[token]; ok {
+				continue
+			}
+			if existing, ok := tokenVersions[token]; ok && existing != version {
+				delete(tokenVersions, token)
+				conflicting[token] = struct{}{}
+				continue
+			}
+			tokenVersions[token] = version
+		}
+	}
+	return tokenVersions
+}
 
 // lookupTechVersion finds a wappalyzer version for a CPE product using exact
 // and alias keys derived from awesome-search-queries naming conventions.
 //
-// If no exact key matches, it falls back to substring containment between the
-// CPE product's lookup keys and each detected technology's normalized name.
-// This catches the common case where wappalyzer's display name carries a
-// vendor prefix the CPE dictionary's product name omits (e.g. "Apache Tomcat"
-// vs. CPE product "tomcat"), or the reverse, where the CPE dictionary's name
-// is more specific (e.g. wappalyzer's "D3" vs. CPE product "d3.js").
-func lookupTechVersion(product string, versions map[string]string) (string, bool) {
+// If no exact key matches, it falls back to tokenVersions: a whole-word index
+// of every detected technology's name (see buildTechVersionTokenIndex). This
+// catches the common case where wappalyzer's display name carries a vendor
+// prefix the CPE dictionary's product name omits (e.g. "Apache Tomcat" vs.
+// CPE product "tomcat"), while whole-word matching - rather than raw
+// substring containment - keeps lexically similar but unrelated products
+// (e.g. "React" vs. "Preact") from being confused for one another.
+func lookupTechVersion(product string, versions, tokenVersions map[string]string) (string, bool) {
 	keys := productLookupKeys(product)
 	for _, key := range keys {
 		if version, ok := versions[key]; ok {
@@ -258,17 +355,9 @@ func lookupTechVersion(product string, versions map[string]string) (string, bool
 		}
 	}
 
-	for _, key := range keys {
-		if len(key) < minSubstringMatchLen {
-			continue
-		}
-		for techName, version := range versions {
-			if len(techName) < minSubstringMatchLen {
-				continue
-			}
-			if strings.Contains(techName, key) || strings.Contains(key, techName) {
-				return version, true
-			}
+	for _, token := range strongTokens(product) {
+		if version, ok := tokenVersions[token]; ok {
+			return version, true
 		}
 	}
 
@@ -314,15 +403,17 @@ func EnrichCPEVersions(matches []CPEInfo, technologies []string) []CPEInfo {
 		return append([]CPEInfo(nil), matches...)
 	}
 	versions := buildTechVersionMap(technologies)
+	tokenVersions := buildTechVersionTokenIndex(technologies)
 
 	enriched := make([]CPEInfo, len(matches))
 	for i, match := range matches {
 		enriched[i] = match
-		if version, ok := lookupTechVersion(match.Product, versions); ok {
+		if version, ok := lookupTechVersion(match.Product, versions, tokenVersions); ok {
 			enriched[i].CPE = setCPEVersion(match.CPE, version)
 		}
 	}
 	return enriched
+
 }
 
 func (d *CPEDetector) extractPattern(query string, info CPEInfo) {

--- a/runner/cpe_test.go
+++ b/runner/cpe_test.go
@@ -203,6 +203,16 @@ func TestProductLookupKeys(t *testing.T) {
 			want: []string{"nextjs"},
 		},
 		{
+			name: "known short alias",
+			in:   "d3.js",
+			want: []string{"d3js", "d3"},
+		},
+		{
+			name: "known display alias",
+			in:   "matomo",
+			want: []string{"matomo", "matomoanalytics"},
+		},
+		{
 			name: "empty",
 			in:   "",
 			want: nil,
@@ -223,6 +233,38 @@ func TestProductLookupKeys(t *testing.T) {
 	}
 }
 
+func TestFallbackProductLookupKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "bare product", in: "tomcat", want: []string{"tomcat"}},
+		{name: "known suffix", in: "confluence_server", want: []string{"confluenceserver", "confluence"}},
+		{name: "known short alias", in: "d3.js", want: []string{"d3js", "d3"}},
+		{name: "known display alias", in: "matomo", want: []string{"matomo", "matomoanalytics"}},
+		{name: "does not use arbitrary prefix", in: "tomcat_jk_connector", want: []string{"tomcatjkconnector"}},
+		{name: "compound uses primary", in: "digital_experience_platform,liferay_portal", want: []string{"digitalexperienceplatform", "digitalexperience"}},
+		{name: "empty", in: "", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fallbackProductLookupKeys(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("fallbackProductLookupKeys(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("fallbackProductLookupKeys(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestLookupTechVersion(t *testing.T) {
 	t.Parallel()
 
@@ -234,9 +276,12 @@ func TestLookupTechVersion(t *testing.T) {
 		"Ansible:2.14.0",
 		"Apache Tomcat:9.0.65",
 		"Preact:10.5.0",
+		"D3:7.8.5",
+		"Atlassian Jira:9.12.0",
+		"Matomo Analytics:5.0.0",
 	}
 	versions := buildTechVersionMap(technologies)
-	tokenVersions := buildTechVersionTokenIndex(technologies)
+	candidates := buildTechnologyVersions(technologies)
 
 	tests := []struct {
 		product   string
@@ -255,6 +300,9 @@ func TestLookupTechVersion(t *testing.T) {
 		// bare CPE product name ("tomcat") - resolved by the whole-word
 		// token fallback.
 		{"tomcat", "9.0.65", true},
+		{"d3.js", "7.8.5", true},
+		{"jira", "9.12.0", true},
+		{"matomo", "5.0.0", true},
 		// CodeRabbit review on #2569: "react" is a character-for-character
 		// substring of "preact", but they must never be treated as a match.
 		// Whole-word tokenization keeps them distinct ("react" != "preact"
@@ -263,12 +311,218 @@ func TestLookupTechVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.product, func(t *testing.T) {
-			got, ok := lookupTechVersion(tt.product, versions, tokenVersions)
+			vendor := map[string]string{
+				"tomcat": "apache",
+				"jira":   "atlassian",
+			}[tt.product]
+			got, ok := lookupTechVersion(tt.product, vendor, versions, candidates)
 			if ok != tt.wantFound {
 				t.Fatalf("lookupTechVersion(%q) found = %v, want %v", tt.product, ok, tt.wantFound)
 			}
 			if got != tt.want {
 				t.Fatalf("lookupTechVersion(%q) = %q, want %q", tt.product, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTechnologyTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "vendor prefix", in: "Apache Tomcat", want: []string{"apache", "tomcat"}},
+		{name: "punctuation", in: "D3.js / Plugin", want: []string{"d3", "js", "plugin"}},
+		{name: "underscore", in: "dashboard_console", want: []string{"dashboard", "console"}},
+		{name: "case folding", in: "PreACT", want: []string{"preact"}},
+		{name: "empty", in: "", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := technologyTokens(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("technologyTokens(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("technologyTokens(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStrongTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "keeps specific words", in: "Apache Tomcat Server", want: []string{"apache", "tomcat"}},
+		{name: "drops generic words", in: "Cloud Web Application Framework", want: nil},
+		{name: "drops short words", in: "D3.js API", want: nil},
+		{name: "keeps token boundaries", in: "React Preact", want: []string{"react", "preact"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strongTokens(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("strongTokens(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("strongTokens(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTechnologyVersions(t *testing.T) {
+	t.Parallel()
+
+	candidates := buildTechnologyVersions([]string{
+		"Apache Tomcat:9.0.65",
+		"Oracle Tomcat:10.1.0",
+		"Vendor Dashboard:1.0",
+		"D3:7.8.5",
+		"Missing Version",
+		"Blank:",
+		"---:1.0",
+	})
+	if len(candidates) != 4 {
+		t.Fatalf("candidates = %#v, want 4 versioned candidates", candidates)
+	}
+	if candidates[0].version != "9.0.65" {
+		t.Fatalf("first candidate version = %q, want 9.0.65", candidates[0].version)
+	}
+	for _, token := range []string{"apache", "tomcat"} {
+		if !sliceContains(candidates[0].tokens, token) {
+			t.Fatalf("first candidate tokens = %v, want %q", candidates[0].tokens, token)
+		}
+	}
+}
+
+func TestLookupTechVersionRejectsAmbiguousFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		product      string
+		vendor       string
+		technologies []string
+		want         string
+		wantFound    bool
+	}{
+		{
+			name:         "same fallback name has different versions",
+			product:      "dashboard",
+			vendor:       "acmecorp",
+			technologies: []string{"AcmeCorp Dashboard:1.0", "AcmeCorp Dashboard:2.0"},
+		},
+		{
+			name:         "conflict is independent of input order",
+			product:      "dashboard",
+			vendor:       "acmecorp",
+			technologies: []string{"AcmeCorp Dashboard:2.0", "AcmeCorp Dashboard:1.0"},
+		},
+		{
+			name:         "vendor disambiguates shared product token",
+			product:      "tomcat",
+			vendor:       "apache",
+			technologies: []string{"Apache Tomcat:9.0.65", "Oracle Tomcat:10.1.0"},
+			want:         "9.0.65",
+			wantFound:    true,
+		},
+		{
+			name:         "matching fallback candidates agree",
+			product:      "dashboard",
+			vendor:       "acmecorp",
+			technologies: []string{"AcmeCorp Dashboard:1.0", "AcmeCorp Dashboard:1.0"},
+			want:         "1.0",
+			wantFound:    true,
+		},
+		{
+			name:         "secondary compound product is ignored",
+			product:      "digital_experience_platform,liferay_portal",
+			vendor:       "acmecorp",
+			technologies: []string{"AcmeCorp Liferay:7.3.5"},
+		},
+		{
+			name:         "exact match wins before ambiguous fallback",
+			product:      "dashboard_console",
+			vendor:       "acmecorp",
+			technologies: []string{"Dashboard Console:9.0", "AcmeCorp Dashboard:1.0", "AcmeCorp Dashboard:2.0"},
+			want:         "9.0",
+			wantFound:    true,
+		},
+		{
+			name:         "shared brand is not product evidence",
+			product:      "google_maps",
+			vendor:       "google",
+			technologies: []string{"Google Analytics:4.0"},
+		},
+		{
+			name:         "unrelated vendor rejects broad product token",
+			product:      "wp-google-maps",
+			vendor:       "wpgmaps",
+			technologies: []string{"Google Analytics:4.0"},
+		},
+		{
+			name:         "extended vendor product is not shortened",
+			product:      "experience_manager",
+			vendor:       "adobe",
+			technologies: []string{"Adobe Experience Manager Edge Delivery Services:1.0"},
+		},
+		{
+			name:         "connector is not parent product",
+			product:      "tomcat_jk_connector",
+			vendor:       "apache",
+			technologies: []string{"Apache Tomcat:9.0.65"},
+		},
+		{
+			name:         "code editor is not visual studio",
+			product:      "visual_studio_code",
+			vendor:       "microsoft",
+			technologies: []string{"Microsoft Visual Studio:17.0"},
+		},
+		{
+			name:         "service management is not jira",
+			product:      "jira_service_management",
+			vendor:       "atlassian",
+			technologies: []string{"Atlassian Jira:10.0"},
+		},
+		{
+			name:         "jquery family name is not jquery",
+			product:      "jquery-bbq",
+			vendor:       "jquery-bbq_project",
+			technologies: []string{"jQuery:3.7.0"},
+		},
+		{
+			name:         "wordpress is not microsoft word",
+			product:      "wordpress",
+			vendor:       "wordpress",
+			technologies: []string{"Microsoft Word:16.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := lookupTechVersion(
+				tt.product,
+				tt.vendor,
+				buildTechVersionMap(tt.technologies),
+				buildTechnologyVersions(tt.technologies),
+			)
+			if ok != tt.wantFound || got != tt.want {
+				t.Fatalf("lookupTechVersion(%q) = %q, %v; want %q, %v", tt.product, got, ok, tt.want, tt.wantFound)
 			}
 		})
 	}
@@ -334,7 +588,7 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 			wantCPE:      "cpe:2.3:a:redhat:ansible_policy_manager:2.14.0:*:*:*:*:*:*:*",
 		},
 		{
-		
+
 			name:         "conflicting tech versions leave cpe unchanged",
 			product:      "liferay_portal",
 			vendor:       "liferay",
@@ -355,18 +609,15 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 			wantCPE:      "cpe:2.3:a:apache:tomcat:9.0.65:*:*:*:*:*:*:*",
 		},
 		{
-			// Reverse case: the CPE product name is more specific than
-			// wappalyzer's short display name. Both tokens ("d3", "js") fall
-			// below minTokenMatchLen, so this documents a known limitation
-			// rather than a fixed case.
+			// Reverse case: a narrow alias bridges the CPE product "d3.js" to
+			// wappalyzer's short display name without weakening token guards.
 			name:         "bare wappalyzer name matches suffixed CPE product (#2550)",
 			product:      "d3.js",
 			vendor:       "d3.js_project",
 			cpe:          "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:*:*:*",
 			technologies: []string{"D3:7.8.5"},
-			wantCPE:      "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:*:*:*",
+			wantCPE:      "cpe:2.3:a:d3.js_project:d3.js:7.8.5:*:*:*:*:*:*:*",
 		},
-	
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -460,6 +711,74 @@ func TestEnrichCPEVersionsWithRealWappalyzer(t *testing.T) {
 	got := EnrichCPEVersions(matches, technologies)
 	if got[0].CPE != "cpe:2.3:a:liferay:liferay_portal:7.3.5:*:*:*:*:*:*:*" {
 		t.Fatalf("liferay CPE = %q, want version 7.3.5 injected end-to-end", got[0].CPE)
+	}
+}
+
+func TestEnrichTomcatCPEWithRealDatasets(t *testing.T) {
+	wappalyze, err := wappalyzer.New()
+	if err != nil {
+		t.Fatalf("could not create wappalyzer: %s", err)
+	}
+
+	info := wappalyze.FingerprintWithInfo(map[string][]string{
+		"x-powered-by": {"Tomcat-9.0.65"},
+	}, nil)
+	var technologies []string
+	for name := range info {
+		technologies = append(technologies, name)
+	}
+	if !sliceContains(technologies, "Apache Tomcat:9.0.65") {
+		t.Fatalf("expected real wappalyzer data to emit Apache Tomcat:9.0.65, got %v", technologies)
+	}
+
+	detector, err := NewCPEDetector()
+	if err != nil {
+		t.Fatalf("could not create CPE detector: %s", err)
+	}
+	matches := detector.Detect("", "Apache Tomcat", "")
+	var found bool
+	for _, match := range EnrichCPEVersions(matches, technologies) {
+		if match.Product != "tomcat" {
+			continue
+		}
+		found = true
+		want := "cpe:2.3:a:apache:tomcat:9.0.65:*:*:*:*:*:*:*"
+		if match.CPE != want {
+			t.Fatalf("Tomcat CPE = %q, want %q", match.CPE, want)
+		}
+	}
+	if !found {
+		t.Fatalf("real awesome-search-queries data did not detect the Tomcat product; matches: %v", matches)
+	}
+}
+
+func TestEnrichVendorPrefixedTechnologiesIndependently(t *testing.T) {
+	matches := []CPEInfo{
+		{
+			Product: "tomcat",
+			Vendor:  "apache",
+			CPE:     "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+		},
+		{
+			Product: "http_server",
+			Vendor:  "apache",
+			CPE:     "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+		},
+	}
+	technologies := []string{
+		"Apache Tomcat:9.0.65",
+		"Apache HTTP Server:2.4.62",
+	}
+
+	got := EnrichCPEVersions(matches, technologies)
+	want := []string{
+		"cpe:2.3:a:apache:tomcat:9.0.65:*:*:*:*:*:*:*",
+		"cpe:2.3:a:apache:http_server:2.4.62:*:*:*:*:*:*:*",
+	}
+	for i := range want {
+		if got[i].CPE != want[i] {
+			t.Fatalf("CPE[%d] = %q, want %q", i, got[i].CPE, want[i])
+		}
 	}
 }
 

--- a/runner/cpe_test.go
+++ b/runner/cpe_test.go
@@ -328,6 +328,31 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 			technologies: []string{"Liferay:7.3.5", "Liferay:7.4.0"},
 			wantCPE:      "cpe:2.3:a:liferay:liferay_portal:*:*:*:*:*:*:*:*",
 		},
+		{
+			// #2550: wappalyzer's display name carries a vendor prefix
+			// ("Apache Tomcat") that awesome-search-queries' bare CPE
+			// product name ("tomcat") doesn't. Neither the exact key nor
+			// any suffix-stripped alias of "tomcat" ever equals
+			// "apachetomcat", so the exact-match lookup can never find it -
+			// this needs the substring fallback.
+			name:         "vendor-prefixed wappalyzer name matches bare CPE product (#2550)",
+			product:      "tomcat",
+			vendor:       "apache",
+			cpe:          "cpe:2.3:a:apache:tomcat:*:*:*:*:*:*:*:*",
+			technologies: []string{"Apache Tomcat:9.0.65"},
+			wantCPE:      "cpe:2.3:a:apache:tomcat:9.0.65:*:*:*:*:*:*:*",
+		},
+		{
+			// Reverse case: the CPE product name is more specific than
+			// wappalyzer's short display name.
+			name:         "bare wappalyzer name matches suffixed CPE product (#2550)",
+			product:      "d3.js",
+			vendor:       "d3.js_project",
+			cpe:          "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:*:*:*",
+			technologies: []string{"D3:7.8.5"},
+			wantCPE:      "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:*:*:*",
+		},
+	
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/runner/cpe_test.go
+++ b/runner/cpe_test.go
@@ -226,13 +226,17 @@ func TestProductLookupKeys(t *testing.T) {
 func TestLookupTechVersion(t *testing.T) {
 	t.Parallel()
 
-	versions := buildTechVersionMap([]string{
+	technologies := []string{
 		"Liferay:7.3.5",
 		"Confluence:8.5.1",
 		"Tableau:2023.1",
 		"Apache HTTP Server:2.4.7",
 		"Ansible:2.14.0",
-	})
+		"Apache Tomcat:9.0.65",
+		"Preact:10.5.0",
+	}
+	versions := buildTechVersionMap(technologies)
+	tokenVersions := buildTechVersionTokenIndex(technologies)
 
 	tests := []struct {
 		product   string
@@ -247,10 +251,19 @@ func TestLookupTechVersion(t *testing.T) {
 		{"Apache HTTP Server", "2.4.7", true},
 		{"phpcollab", "", false},
 		{"unknown_product", "", false},
+		// #2550: vendor-prefixed wappalyzer name ("Apache Tomcat") vs. the
+		// bare CPE product name ("tomcat") - resolved by the whole-word
+		// token fallback.
+		{"tomcat", "9.0.65", true},
+		// CodeRabbit review on #2569: "react" is a character-for-character
+		// substring of "preact", but they must never be treated as a match.
+		// Whole-word tokenization keeps them distinct ("react" != "preact"
+		// as tokens), unlike a raw substring check.
+		{"react", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.product, func(t *testing.T) {
-			got, ok := lookupTechVersion(tt.product, versions)
+			got, ok := lookupTechVersion(tt.product, versions, tokenVersions)
 			if ok != tt.wantFound {
 				t.Fatalf("lookupTechVersion(%q) found = %v, want %v", tt.product, ok, tt.wantFound)
 			}
@@ -321,6 +334,7 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 			wantCPE:      "cpe:2.3:a:redhat:ansible_policy_manager:2.14.0:*:*:*:*:*:*:*",
 		},
 		{
+		
 			name:         "conflicting tech versions leave cpe unchanged",
 			product:      "liferay_portal",
 			vendor:       "liferay",
@@ -331,10 +345,8 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 		{
 			// #2550: wappalyzer's display name carries a vendor prefix
 			// ("Apache Tomcat") that awesome-search-queries' bare CPE
-			// product name ("tomcat") doesn't. Neither the exact key nor
-			// any suffix-stripped alias of "tomcat" ever equals
-			// "apachetomcat", so the exact-match lookup can never find it -
-			// this needs the substring fallback.
+			// product name ("tomcat") doesn't. Resolved by the whole-word
+			// token fallback in lookupTechVersion.
 			name:         "vendor-prefixed wappalyzer name matches bare CPE product (#2550)",
 			product:      "tomcat",
 			vendor:       "apache",
@@ -344,7 +356,9 @@ func TestEnrichCPEVersionsIssue2536(t *testing.T) {
 		},
 		{
 			// Reverse case: the CPE product name is more specific than
-			// wappalyzer's short display name.
+			// wappalyzer's short display name. Both tokens ("d3", "js") fall
+			// below minTokenMatchLen, so this documents a known limitation
+			// rather than a fixed case.
 			name:         "bare wappalyzer name matches suffixed CPE product (#2550)",
 			product:      "d3.js",
 			vendor:       "d3.js_project",


### PR DESCRIPTION
## Proposed changes

Fixes #2550

`#2509` and `#2538` fixed CPE version enrichment for the exact-match case, but #2550 shows it's still broken for a large class of products. wappalyzer's display names often carry a vendor prefix that the CPE dictionary's bare product name omits (e.g. `"Apache Tomcat"` vs CPE product `"tomcat"`), or the reverse. The exact-match lookup in `lookupTechVersion` can never bridge that gap, so the CPE version field stays `*` even when the version is known.

This adds a length-guarded substring fallback: if no exact key matches, it checks whether a CPE product's lookup key is a substring of (or contains) a detected technology's normalized name, requiring both sides to be at least 5 characters to avoid false positives on short generic keys (`web`, `cms`, etc.).

### Proof

Added two new cases to `TestEnrichCPEVersionsIssue2536` in `runner/cpe_test.go`:
- `"Apache Tomcat:9.0.65"` detected + CPE product `"tomcat"` -> version `9.0.65` now gets injected (previously stayed `*`)
- `"D3:7.8.5"` detected + CPE product `"d3.js"` -> documents the reverse case

Ran locally:
go vet ./...
go test ./runner/...
Both clean — all existing tests in `runner/cpe_test.go` still pass unchanged, plus the two new cases.

## Checklist

- [x] Pull request is created against the [dev](https://github.com/projectdiscovery/httpx/tree/dev) branch
- [x] All checks passed (lint, unit/integration/regression tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved technology version matching when names differ between detection sources.
  * Supports vendor-prefixed technology names and known aliases, including D3.js and Matomo.
  * Prevents short, generic, or substring-based names from producing incorrect matches.
  * Rejects ambiguous matches when available technology candidates conflict.
  * Preserves existing product identifiers when a reliable match cannot be determined.
  * Improved enrichment accuracy for technologies with meaningful multi-word names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->