### PR TITLE
chore(ci): update CodeQL actions to supported versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '**.go'
+      - '.github/workflows/codeql-analysis.yml'
     branches:
       - dev
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Proposed changes

Update the CodeQL workflow from the retired v2 action line to the supported v4 line, and align checkout with the v4 version already used by the rest of this repository.

This is a minimal follow-up to the maintainer feedback on #2553: it uses version tags rather than commit SHA pins and changes no other workflows or permissions.

### Proof

- actionlint passes for .github/workflows/codeql-analysis.yml
- go test ./... passes on the unchanged source baseline with Go 1.27.1
- git diff --check passes
- CodeQL officially supports v4 and v3; v2 is no longer supported

## Checklist

- [x] Pull request is created against the dev branch
- [x] All applicable local checks passed
- [x] No product test is required for a version-only workflow update
- [x] No documentation change is required

Submitted by @Gh0stlyKn1ght.