### PR TITLE
fix: handle quoted charset and non-canonical content-type in title extraction

### DIFF
--- a/common/httpx/encodings.go
+++ b/common/httpx/encodings.go
@@ -58,6 +58,8 @@ func DecodeData(data []byte, headers http.Header) ([]byte, error) {
 	// Non UTF-8
 	if contentTypes, ok := headers["Content-Type"]; ok {
 		contentType := strings.ToLower(strings.Join(contentTypes, ";"))
+		// the charset parameter value can be a quoted string (charset="gbk")
+		contentType = strings.ReplaceAll(contentType, `"`, "")
 
 		switch {
 		case stringsutil.ContainsAny(contentType, "charset=gb2312", "charset=gbk"):

--- a/common/httpx/title.go
+++ b/common/httpx/title.go
@@ -51,7 +51,7 @@ func ExtractTitle(r *Response) (title string) {
 }
 
 func CanHaveTitleTag(mimeType string) bool {  
-    return slices.Contains(supportedTitleMimeTypes, mimeType)  
+    return slices.Contains(supportedTitleMimeTypes, strings.ToLower(strings.TrimSpace(mimeType)))  
 }  
 
 func getTitleWithDom(r *Response) (*html.Node, error) {

--- a/common/httpx/title_test.go
+++ b/common/httpx/title_test.go
@@ -1,0 +1,72 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/retryablehttp-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanHaveTitleTag(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		{"text/html", true},
+		{"TEXT/HTML", true},
+		{"Text/Html", true},
+		{"text/html ", true},
+		{" application/xhtml+xml", true},
+		{"text/plain", false},
+		{"application/json", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			require.Equal(t, tt.expected, CanHaveTitleTag(tt.mimeType))
+		})
+	}
+}
+
+func TestExtractTitleDecodesCharset(t *testing.T) {
+	options := DefaultOptions
+	options.CdnCheck = "false"
+	options.Timeout = 2 * time.Second
+	options.RetryMax = 0
+
+	ht, err := New(&options)
+	require.Nil(t, err)
+
+	// <title>中文</title> with the title text encoded in GBK
+	gbk := []byte{0xd6, 0xd0, 0xce, 0xc4}
+	body := append([]byte("<html><head><title>"), gbk...)
+	body = append(body, []byte("</title></head></html>")...)
+
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{"quoted charset", `text/html; charset="gbk"`},
+		{"unquoted charset", "text/html; charset=gbk"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = w.Write(body)
+			}))
+			defer srv.Close()
+
+			req, err := retryablehttp.NewRequest(http.MethodGet, srv.URL, nil)
+			require.Nil(t, err)
+			resp, err := ht.Do(req, UnsafeOptions{})
+			require.Nil(t, err)
+			require.Equal(t, "中文", ExtractTitle(resp))
+		})
+	}
+}


### PR DESCRIPTION
httpx silently drops the title, or extracts it as mojibake, when the `Content-Type` response header deviates from the canonical lowercase form:

- `Content-Type: text/html; charset="gbk"` — the quoted charset value (legal per RFC 9110) is not matched by the `charset=gbk` substring check in `DecodeData`, so GBK/EUC-KR bodies are never transcoded and the title comes out as raw bytes
- `Content-Type: TEXT/HTML` or `text/html ; charset=utf-8` — media types are case-insensitive and optional whitespace is allowed before parameters, but `CanHaveTitleTag` compares the value verbatim, so the title extraction is skipped entirely

```
$ httpx -u http://127.0.0.1:8000 -title
# content-type: text/html; charset="gbk"        -> []  (raw GBK bytes)
# content-type: TEXT/HTML                       -> (no title at all)
```

This strips quotes from the joined content-type before the charset matching, and normalizes the mime type (case + surrounding whitespace) in `CanHaveTitleTag`. Responses with canonical headers are unaffected. Regression tests cover both the quoted-charset and case/whitespace variants end-to-end (`TestCanHaveTitleTag`, `TestExtractTitleDecodesCharset`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of quoted character-set values in HTTP content types, ensuring titles encoded with GBK and similar formats display correctly.
  - MIME type detection now handles capitalization differences and surrounding whitespace, improving recognition of HTML content.

- **Tests**
  - Added coverage for MIME type normalization and decoding titles from quoted and unquoted character-set declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->