### PR TITLE
test(httputilz): add multi-valued query parameter parsing specs

### DIFF
--- a/common/httputilz/day2_w17_query_test.go
+++ b/common/httputilz/day2_w17_query_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithMultiValuedQueryParams(t *testing.T) {
+	raw := "GET /search?q=test&q=override HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/search?q=test&q=override", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling multi-valued query parameters in request URI.\n\n### Testing\n- Tested with go test ./common/httputilz/...