### PR TITLE
test(httputilz): add URL path percent encoding preservation specs

### DIFF
--- a/common/httputilz/day2_w18_space_test.go
+++ b/common/httputilz/day2_w18_space_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithURLPathPercentEncoding(t *testing.T) {
+	raw := "GET /api/v1/user%20profile HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/api/v1/user%20profile", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` preserving percent-encoded spaces in request URI.\n\n### Testing\n- Tested with go test ./common/httputilz/...