### PR TITLE
test(httputilz): add mixed-case header parsing normalization specs

### DIFF
--- a/common/httputilz/day2_w19_casing_test.go
+++ b/common/httputilz/day2_w19_casing_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithMixedCaseHeaders(t *testing.T) {
+	raw := "GET / HTTP/1.1\r\nHoSt: example.com\r\nAcCePt: text/html\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "example.com", req.Host)
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling mixed-case HTTP headers.\n\n### Testing\n- Tested with go test ./common/httputilz/...