### PR TITLE
test(httputilz): add padded header whitespace trimming specs

### DIFF
--- a/common/httputilz/day2_w20_whitespace_test.go
+++ b/common/httputilz/day2_w20_whitespace_test.go
@@ -1,0 +1,16 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithPaddedHeaderValues(t *testing.T) {
+	raw := "GET /status HTTP/1.1\r\nHost:   example.com   \r\nX-Custom-Key:   value123   \r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "example.com", req.Host)
+	require.Equal(t, []string{"value123"}, req.Header["X-Custom-Key"])
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` properly trimming surrounding whitespace from header values.\n\n### Testing\n- Tested with go test ./common/httputilz/...