### PR TITLE
test(httputilz): add multiple trailing CRLF request parsing specs

### DIFF
--- a/common/httputilz/day2_w21_crlf_test.go
+++ b/common/httputilz/day2_w21_crlf_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithMultipleCRLFSequences(t *testing.T) {
+	raw := "POST /v1/batch HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/v1/batch", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling trailing CRLF byte sequences without error.\n\n### Testing\n- Tested with go test ./common/httputilz/...