### PR TITLE
test(httputilz): add multiple Cookie header parsing specs

### DIFF
--- a/common/httputilz/day2_w22_cookie_test.go
+++ b/common/httputilz/day2_w22_cookie_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithMultipleCookieHeaders(t *testing.T) {
+	raw := "GET /dashboard HTTP/1.1\r\nHost: example.com\r\nCookie: session_id=xyz123\r\nCookie: theme=dark\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/dashboard", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling multiple consecutive Cookie headers.\n\n### Testing\n- Tested with go test ./common/httputilz/...