### PR TITLE
fix(runner): use os.CreateTemp and mutex serialization for atomic resume on Windows

### DIFF
--- a/runner/atomic_resume.go
+++ b/runner/atomic_resume.go
@@ -1,0 +1,36 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var atomicResumeMutex sync.Mutex
+
+func SaveAtomic(targetPath string, data []byte) error {
+	atomicResumeMutex.Lock()
+	defer atomicResumeMutex.Unlock()
+
+	dir := filepath.Dir(targetPath)
+	tmpFile, err := os.CreateTemp(dir, "httpx-resume-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmpFile.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, targetPath)
+}


### PR DESCRIPTION
Resolves #2586.

/claim #2586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable atomic saving for resume configuration files, helping prevent partially written or corrupted files if a write operation fails.
  - Concurrent save operations are serialized to ensure consistent results.
  - Resume configuration updates are now safely finalized only after the complete file has been written and synchronized. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->