### PR TITLE
test(httputilz): add custom HTTP method PURGE parsing specs

### DIFF
--- a/common/httputilz/day2_w25_custom_verb_test.go
+++ b/common/httputilz/day2_w25_custom_verb_test.go
@@ -1,0 +1,16 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithCustomHTTPVerb(t *testing.T) {
+	raw := "PURGE /cache/resource HTTP/1.1\r\nHost: cdn.example.com\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "PURGE", req.Method)
+	require.Equal(t, "/cache/resource", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling extension HTTP verbs like PURGE.\n\n### Testing\n- Tested with go test ./common/httputilz/...