### PR TITLE
test(httputilz): add OPTIONS asterisk URI parsing specs

### DIFF
--- a/common/httputilz/day2_w26_options_test.go
+++ b/common/httputilz/day2_w26_options_test.go
@@ -1,0 +1,16 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithOptionsAsterisk(t *testing.T) {
+	raw := "OPTIONS * HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "OPTIONS", req.Method)
+	require.Equal(t, "*", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling standard OPTIONS * requests.\n\n### Testing\n- Tested with go test ./common/httputilz/...