### PR TITLE
test(httputilz): add HEAD method request parsing specs

### DIFF
--- a/common/httputilz/day2_w27_head_test.go
+++ b/common/httputilz/day2_w27_head_test.go
@@ -1,0 +1,16 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithHeadMethod(t *testing.T) {
+	raw := "HEAD /assets/bundle.js HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "HEAD", req.Method)
+	require.Equal(t, "/assets/bundle.js", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling standard HEAD requests.\n\n### Testing\n- Tested with go test ./common/httputilz/...