### PR TITLE
test(httputilz): add TRACE method request parsing specs

### DIFF
--- a/common/httputilz/day2_w28_trace_test.go
+++ b/common/httputilz/day2_w28_trace_test.go
@@ -1,0 +1,16 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithTraceMethod(t *testing.T) {
+	raw := "TRACE / HTTP/1.1\r\nHost: example.com\r\nMax-Forwards: 10\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "TRACE", req.Method)
+	require.Equal(t, "/", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling standard TRACE requests.\n\n### Testing\n- Tested with go test ./common/httputilz/...