### PR TITLE
test(httputilz): add multiple transfer encoding header parsing specs

### DIFF
--- a/common/httputilz/day3_w02_te_test.go
+++ b/common/httputilz/day3_w02_te_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithMultipleTransferEncodings(t *testing.T) {
+	raw := "POST /data HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/data", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling comma-separated Transfer-Encoding headers.\n\n### Testing\n- Tested with go test ./common/httputilz/...