### PR TITLE
test(httputilz): add IPv6 bracket Host header parsing specs

### DIFF
--- a/common/httputilz/day3_w03_ipv6_test.go
+++ b/common/httputilz/day3_w03_ipv6_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithIPv6HostHeader(t *testing.T) {
+	raw := "GET /status HTTP/1.1\r\nHost: [2001:db8::1]:8080\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "[2001:db8::1]:8080", req.Host)
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling bracketed IPv6 host headers with ports.\n\n### Testing\n- Tested with go test ./common/httputilz/...