### PR TITLE
test(httputilz): add Content-Length zero body preservation specs

### DIFF
--- a/common/httputilz/day3_w08_zero_test.go
+++ b/common/httputilz/day3_w08_zero_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithContentLengthZero(t *testing.T) {
+	raw := "POST /api/v1/ping HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, int64(0), req.ContentLength)
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling zero-length POST request payloads.\n\n### Testing\n- Tested with go test ./common/httputilz/...