### PR TITLE
test(httputilz): add Accept-Language locale parsing specs

### DIFF
--- a/common/httputilz/day3_w12_lang_test.go
+++ b/common/httputilz/day3_w12_lang_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithAcceptLanguageLocales(t *testing.T) {
+	raw := "GET /intl/home HTTP/1.1\r\nHost: example.com\r\nAccept-Language: en-US,en;q=0.9,fr-CA;q=0.7,fr;q=0.8\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/intl/home", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling complex Accept-Language weighted locale headers.\n\n### Testing\n- Tested with go test ./common/httputilz/...