### PR TITLE
test(httputilz): add Via proxy header preservation specs

### DIFF
--- a/common/httputilz/day3_w16_via_test.go
+++ b/common/httputilz/day3_w16_via_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithViaProxyHeader(t *testing.T) {
+	raw := "GET /healthz HTTP/1.1\r\nHost: example.com\r\nVia: 1.1 vegur, 2.0 varnish-cache\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "example.com", req.Host)
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling multi-proxy Via upstream hop headers.\n\n### Testing\n- Tested with go test ./common/httputilz/...