### PR TITLE
test(httputilz): add Upgrade-Insecure-Requests header preservation specs

### DIFF
--- a/common/httputilz/day3_w18_upgrade_test.go
+++ b/common/httputilz/day3_w18_upgrade_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithUpgradeInsecureRequests(t *testing.T) {
+	raw := "GET /secure/app HTTP/1.1\r\nHost: example.com\r\nUpgrade-Insecure-Requests: 1\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "/secure/app", req.URL.RequestURI())
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling Upgrade-Insecure-Requests client hints.\n\n### Testing\n- Tested with go test ./common/httputilz/...