### PR TITLE
test(httputilz): add Proxy-Authorization header preservation specs

### DIFF
--- a/common/httputilz/day3_w19_proxyauth_test.go
+++ b/common/httputilz/day3_w19_proxyauth_test.go
@@ -1,0 +1,15 @@
+package httputilz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestWithProxyAuthorization(t *testing.T) {
+	raw := "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\nProxy-Authorization: Basic dXNlcjpwYXNzMTIz\r\n\r\n"
+	req, err := ParseRequest(raw, false)
+	require.Nil(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "CONNECT", req.Method)
+}


### PR DESCRIPTION
### Summary\n- Adds unit test verification for `ParseRequest` handling Proxy-Authorization Basic tokens on CONNECT tunnels.\n\n### Testing\n- Tested with go test ./common/httputilz/...