### PR TITLE
fix: don't fail responses whose body was capped by -response-size-to-read

### DIFF
--- a/common/httpx/httpx.go
+++ b/common/httpx/httpx.go
@@ -278,6 +278,9 @@ get_response:
 	// 304 - Not Modified => no body the response terminates with latest header newline
 	shouldSkipBodyRead := generic.EqualsAny(httpresp.StatusCode, http.StatusSwitchingProtocols, http.StatusNotModified)
 
+	// the body is capped before dumping the response to avoid loading unbounded
+	// bodies (or infinite streams) in memory
+	bodyTruncated := h.Options.MaxResponseBodySizeToRead > 0 && httpresp.ContentLength > h.Options.MaxResponseBodySizeToRead
 	if h.Options.MaxResponseBodySizeToRead > 0 {
 		httpresp.Body = io.NopCloser(io.LimitReader(httpresp.Body, h.Options.MaxResponseBodySizeToRead))
 		if !shouldSkipBodyRead {
@@ -294,6 +297,13 @@ get_response:
 		if stringsutil.ContainsAny(err.Error(), "tls: user canceled") {
 			shouldIgnoreErrors = true
 			shouldIgnoreBodyErrors = true
+		}
+
+		// Serializing a response whose body was capped fails with "ContentLength=x with
+		// Body length y", although headers and the truncated body are dumped correctly.
+		// An intentional truncation must not turn a valid response into a failed one.
+		if bodyTruncated && stringsutil.ContainsAny(err.Error(), "with Body length") {
+			shouldIgnoreErrors = true
 		}
 
 		// Edge case - some servers respond with gzip encoding header but uncompressed body, in this case the standard library configures the reader as gzip, triggering an error when read.

--- a/common/httpx/response_memory_test.go
+++ b/common/httpx/response_memory_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -187,4 +188,35 @@ func TestBodyMetricsCountingDoesNotAllocate(t *testing.T) {
 	require.NotZero(t, words)
 	require.NotZero(t, lines)
 	require.Zerof(t, allocs, "word/line counting must not allocate, got %v allocs/op", allocs)
+}
+
+// TestDoTruncatedBodyIsNotAFailure guards against the regression where capping
+// the body before dumping the response made the dump fail with
+// "ContentLength=x with Body length y", turning a valid response into a failed
+// one (issue #2641).
+func TestDoTruncatedBodyIsNotAFailure(t *testing.T) {
+	body := bytes.Repeat([]byte("A"), 4096)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	}))
+	defer ts.Close()
+
+	const readSize = 10
+	options := DefaultOptions
+	options.CdnCheck = "false"
+	options.Timeout = 5 * time.Second
+	options.RetryMax = 0
+	options.MaxResponseBodySizeToRead = readSize
+
+	ht, err := New(&options)
+	require.NoError(t, err)
+
+	resp := doLocal(t, ht, ts.URL)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, len(body), resp.ContentLength, "advertised content length must be reported")
+	require.Len(t, resp.Data, readSize, "body must be capped to the configured read size")
+	require.Contains(t, resp.RawHeaders, "Content-Length: "+strconv.Itoa(len(body)))
 }


### PR DESCRIPTION
Fixes #2641

### What

A response whose body was capped by `-response-size-to-read` (or by the default 50MB cap) was reported as `status_code: 0, failed: true` with `ContentLength=100194 with Body length 10`.

The cap itself is intentional: since 78bf9c3 the body is wrapped in a `LimitReader` before `pdhttputil.DumpResponseHeadersAndRaw`, so building `resp.Raw` cannot load an unbounded body or an infinite stream in memory. The side effect was not: that dump calls `resp.Write()`, and net/http refuses to serialize a response whose body is shorter than the advertised `Content-Length`, so httpx treated our own truncation as a transport error and dropped the whole result.

When the truncation is ours (`ContentLength > MaxResponseBodySizeToRead`), that serialization error is now tolerated. Headers and the truncated body are already dumped correctly at that point, so `resp.Raw` stays usable. The cap is untouched, memory stays bounded, and a server genuinely lying about `Content-Length` still errors as before.

### Verification

`TestDoTruncatedBodyIsNotAFailure` fails without the fix (`ContentLength=4096 with Body length 10`) and passes with it. Full `./common/httpx/...` suite is green.

Against the URL from the issue:

```
before: error "ContentLength=100194 with Body length 10", status_code 0, failed true
after:  status_code 200, content_length 100194, failed false
```

`raw_header` keeps `Content-Length: 100194` and the body holds the bytes actually read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Large HTTP responses that exceed the configured read limit are now handled successfully instead of being reported as failures.
  - Truncated response bodies retain their status and advertised content length while respecting the configured maximum size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->